### PR TITLE
Php auth add oauth2 base

### DIFF
--- a/src/JustAuth/OAuth2.php
+++ b/src/JustAuth/OAuth2.php
@@ -324,15 +324,16 @@ class OAuth2
   }
 
   /**
-   * Returns the authorization Uri that the user should be redirected to.
+   * Builds the authorization Uri that the user should be redirected to.
    *
    * @param $config configuration options that customize the return url
    * @return GuzzleHttp::Url the authorization Url.
    */
-  public function getAuthorizationUri(array $config = null)
+  public function buildFullAuthorizationUri(array $config = null)
   {
-    if (is_null($this->authorizationUri)) {
-      return null;
+    if (is_null($this->getAuthorizationUri())) {
+      throw new \InvalidArgumentException(
+          'requires an authorizationUri to have been set');
     }
     $defaults = [
         'response_type' => 'code',
@@ -363,7 +364,7 @@ class OAuth2
     // Construct the uri object; return it if it is valid.
     $result = $this->authorizationUri;
     if (is_string($result)) {
-      $result = Url::fromString($this->authorizationUri);
+      $result = Url::fromString($this->getAuthorizationUri());
     }
     $result->getQuery()->merge($params);
     if ($result->getScheme() != 'https') {
@@ -380,6 +381,15 @@ class OAuth2
   public function setAuthorizationUri($uri)
   {
     $this->authorizationUri = $this->coerceUri($uri);
+  }
+
+  /**
+   * Gets the authorization server's HTTP endpoint capable of authenticating
+   * the end-user and obtaining authorization.
+   */
+  public function getAuthorizationUri()
+  {
+    return $this->authorizationUri;
   }
 
   /**

--- a/tests/JustAuth/OAuth2Test.php
+++ b/tests/JustAuth/OAuth2Test.php
@@ -29,10 +29,13 @@ class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
       'clientId' => 'aClientID'
   ];
 
+  /**
+   * @expectedException InvalidArgumentException
+   */
   public function testIsNullIfAuthorizationUriIsNull()
   {
     $o = new OAuth2([]);
-    $this->assertNull($o->getAuthorizationUri());
+    $this->assertNull($o->buildFullAuthorizationUri());
   }
 
   /**
@@ -44,7 +47,7 @@ class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
         'authorizationUri' => 'https://accounts.test.org/auth/url',
         'redirectUri' => 'https://accounts.test.org/redirect/url'
     ]);
-    $o->getAuthorizationUri();
+    $o->buildFullAuthorizationUri();
   }
 
   /**
@@ -56,7 +59,7 @@ class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
         'authorizationUri' => 'https://accounts.test.org/auth/url',
         'clientId' => 'aClientID'
     ]);
-    $o->getAuthorizationUri();
+    $o->buildFullAuthorizationUri();
   }
 
   /**
@@ -68,7 +71,7 @@ class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
         'authorizationUri' => 'https://accounts.test.org/auth/url',
         'clientId' => 'aClientID'
     ]);
-    $o->getAuthorizationUri([
+    $o->buildFullAuthorizationUri([
         'approvalPrompt' => 'an approval prompt',
         'prompt' => 'a prompt',
     ]);
@@ -84,7 +87,7 @@ class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
         'redirectUri' => 'https://accounts.test.org/redirect/url',
         'clientId' => 'aClientID'
     ]);
-    $o->getAuthorizationUri();
+    $o->buildFullAuthorizationUri();
   }
 
   /**
@@ -97,13 +100,13 @@ class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
         'redirectUri' => '/redirect/url',
         'clientId' => 'aClientID'
     ]);
-    $o->getAuthorizationUri();
+    $o->buildFullAuthorizationUri();
   }
 
   public function testHasDefaultXXXTypeParams()
   {
     $o = new OAuth2($this->minimal);
-    $q = $o->getAuthorizationUri()->getQuery();
+    $q = $o->buildFullAuthorizationUri()->getQuery();
     $this->assertEquals('code', $q->get('response_type'));
     $this->assertEquals('offline', $q->get('access_type'));
   }
@@ -114,7 +117,7 @@ class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
         'authorizationUri' => Url::fromString('https://another/uri')
     ]);
     $o = new OAuth2($config);
-    $this->assertEquals('/uri', $o->getAuthorizationUri()->getPath());
+    $this->assertEquals('/uri', $o->buildFullAuthorizationUri()->getPath());
   }
 
   public function testCanOverrideParams()
@@ -128,7 +131,7 @@ class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
     ];
     $config = array_merge($this->minimal, ['state' => 'the_state']);
     $o = new OAuth2($config);
-    $q = $o->getAuthorizationUri($overrides)->getQuery();
+    $q = $o->buildFullAuthorizationUri($overrides)->getQuery();
     $this->assertEquals('o_access_type', $q->get('access_type'));
     $this->assertEquals('o_client_id', $q->get('client_id'));
     $this->assertEquals('o_redirect_uri', $q->get('redirect_uri'));
@@ -140,14 +143,14 @@ class OAuth2AuthorizationUriTest extends \PHPUnit_Framework_TestCase
   {
     $with_strings = array_merge($this->minimal, ['scope' => 'scope1 scope2']);
     $o = new OAuth2($with_strings);
-    $q = $o->getAuthorizationUri()->getQuery();
+    $q = $o->buildFullAuthorizationUri()->getQuery();
     $this->assertEquals('scope1 scope2', $q->get('scope'));
 
     $with_array = array_merge($this->minimal, [
         'scope' => ['scope1', 'scope2']
     ]);
     $o = new OAuth2($with_array);
-    $q = $o->getAuthorizationUri()->getQuery();
+    $q = $o->buildFullAuthorizationUri()->getQuery();
     $this->assertEquals('scope1 scope2', $q->get('scope'));
   }
 


### PR DESCRIPTION
 aims to be similar to signet's  [oauth_2/client.rb](https://github.com/google/signet/blob/master/lib/signet/oauth_2/client.rb)
- incomplete, this first branch leaves out signing and decoding to keep this commit simple, the rest is in a follow-up branch
