### PR TITLE
Include 'sub' in ServiceAccountCredentials cache key, if available

### DIFF
--- a/src/ServiceAccountCredentials.php
+++ b/src/ServiceAccountCredentials.php
@@ -102,5 +102,6 @@ class ServiceAccountCredentials extends CredentialsLoader
     if ($sub = $this->auth->getSub()) {
       $key .= ':' . $sub;
     }
+    return $key;
   }
 }

--- a/tests/ServiceAccountCredentialsTest.php
+++ b/tests/ServiceAccountCredentialsTest.php
@@ -52,6 +52,23 @@ class SACGetCacheKeyTest extends \PHPUnit_Framework_TestCase
         $sa->getCacheKey()
     );
   }
+
+  public function testShouldBeTheSameAsOAuth2WithTheSameScopeWithSub()
+  {
+    $testJson = createTestJson();
+    $scope = ['scope/1', 'scope/2'];
+    $sub = 'sub123';
+    $sa = new ServiceAccountCredentials(
+        $scope,
+        $testJson,
+        null,
+        $sub);
+    $o = new OAuth2(['scope' => $scope]);
+    $this->assertSame(
+        $testJson['client_email'] . ':' . $o->getCacheKey() . ':' . $sub,
+        $sa->getCacheKey()
+    );
+  }
 }
 
 class SACConstructorTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
Include 'sub' in ServiceAccountCredentials cache key, if available. Also added a unit test. The existing unit test just above should cover the case when 'sub' is empty.
