### PR TITLE
Add support for InsecureCredentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *~
 vendor
 composer.lock
+
+# IntelliJ
+.idea
+*.iml

--- a/src/Credentials/InsecureCredentials.php
+++ b/src/Credentials/InsecureCredentials.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Credentials;
+
+use Google\Auth\FetchAuthTokenInterface;
+
+/**
+ * Provides a set of credentials that will always return an empty access token.
+ * This is useful for APIs which do not require authentication, for local
+ * service emulators, and for testing.
+ */
+class InsecureCredentials implements FetchAuthTokenInterface
+{
+    /**
+     * @var array
+     */
+    private $token = [
+        'access_token' => ''
+    ];
+
+    /**
+     * Fetches the auth token. In this case it returns an empty string.
+     *
+     * @param callable $httpHandler
+     * @return array
+     */
+    public function fetchAuthToken(callable $httpHandler = null)
+    {
+        return $this->token;
+    }
+
+    /**
+     * Returns the cache key. In this case it returns a null value, disabling
+     * caching.
+     *
+     * @return string|null
+     */
+    public function getCacheKey()
+    {
+        return null;
+    }
+
+    /**
+     * Fetches the last received token. In this case, it returns the same empty string
+     * auth token.
+     *
+     * @return array
+     */
+    public function getLastReceivedToken()
+    {
+        return $this->token;
+    }
+}

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -17,6 +17,7 @@
 
 namespace Google\Auth;
 
+use Google\Auth\Credentials\InsecureCredentials;
 use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Auth\Credentials\UserRefreshCredentials;
 
@@ -174,6 +175,16 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
             default:
                 throw new \Exception('Version not supported');
         }
+    }
+
+    /**
+     * Create a new instance of InsecureCredentials.
+     *
+     * @return InsecureCredentials
+     */
+    public static function makeInsecureCredentials()
+    {
+        return new InsecureCredentials();
     }
 
     /**

--- a/tests/Credentials/InsecureCredentialsTest.php
+++ b/tests/Credentials/InsecureCredentialsTest.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Tests;
+
+use Google\Auth\Credentials\InsecureCredentials;
+use PHPUnit\Framework\TestCase;
+
+class InsecureCredentialsTest extends TestCase
+{
+    public function testFetchAuthToken()
+    {
+        $insecure = new InsecureCredentials();
+        $this->assertEquals(['access_token' => ''], $insecure->fetchAuthToken());
+    }
+
+    public function testGetCacheKey()
+    {
+        $insecure = new InsecureCredentials();
+        $this->assertNull($insecure->getCacheKey());
+    }
+
+    public function testGetLastReceivedToken()
+    {
+        $insecure = new InsecureCredentials();
+        $this->assertEquals(['access_token' => ''], $insecure->getLastReceivedToken());
+    }
+}


### PR DESCRIPTION
Adds support for insecure credentials, which can be used when calling APIs that don't require credentials (e.g. public buckets), emulators, or test services.

cc @tmatsuo @bshaffer @dwsupplee @jdpedrie 