### PR TITLE
Cache item expiration correctly calculated when DST shifts

### DIFF
--- a/src/Cache/Clock.php
+++ b/src/Cache/Clock.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Google\Auth\Cache;
 

--- a/src/Cache/Clock.php
+++ b/src/Cache/Clock.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Google\Auth\Cache;
+
+final class Clock
+{
+    private static $currentTime;
+
+    /**
+     * @return \DateTime
+     */
+    public static function now()
+    {
+        return self::$currentTime !== null ? clone self::$currentTime : new \DateTime();
+    }
+
+    /**
+     * @param int|\DateInterval $seconds
+     * @throws \InvalidArgumentException When $seconds is not an integer or \DateInterval.
+     * @return \DateTime
+     */
+    public static function after($time)
+    {
+        if (is_int($time)) {
+            $diff = new \DateInterval("PT{$time}S");
+        } elseif ($time instanceof \DateInterval) {
+            $diff = $time;
+        } else {
+            throw new \InvalidArgumentException();
+        }
+
+        return self::now()->add($diff);
+    }
+
+    public static function setTime(\DateTime $time)
+    {
+        self::$currentTime = $time;
+    }
+}

--- a/src/Cache/Item.php
+++ b/src/Cache/Item.php
@@ -81,7 +81,8 @@ final class Item implements CacheItemInterface
             return true;
         }
 
-        return Clock::now()->getTimestamp() < (clone $this->expiration)->getTimestamp();
+        return Clock::now()->setTimezone(new \DateTimeZone('UTC'))->getTimestamp()
+            < (clone $this->expiration)->setTimezone(new \DateTimeZone('UTC'))->getTimestamp();
     }
 
     /**

--- a/src/Cache/Item.php
+++ b/src/Cache/Item.php
@@ -81,8 +81,10 @@ final class Item implements CacheItemInterface
             return true;
         }
 
+        $expiration = clone $this->expiration;
+
         return Clock::now()->setTimezone(new \DateTimeZone('UTC'))->getTimestamp()
-            < (clone $this->expiration)->setTimezone(new \DateTimeZone('UTC'))->getTimestamp();
+            < $expiration->setTimezone(new \DateTimeZone('UTC'))->getTimestamp();
     }
 
     /**

--- a/src/Cache/Item.php
+++ b/src/Cache/Item.php
@@ -81,7 +81,7 @@ final class Item implements CacheItemInterface
             return true;
         }
 
-        return new \DateTime() < $this->expiration;
+        return Clock::now()->getTimestamp() < (clone $this->expiration)->getTimestamp();
     }
 
     /**
@@ -125,18 +125,18 @@ final class Item implements CacheItemInterface
      */
     public function expiresAfter($time)
     {
-        if (is_int($time)) {
-            $this->expiration = new \DateTime("now + $time seconds");
-        } elseif ($time instanceof \DateInterval) {
-            $this->expiration = (new \DateTime())->add($time);
-        } elseif ($time === null) {
+        if ($time === null) {
             $this->expiration = $time;
         } else {
-            $message = 'Argument 1 passed to %s::expiresAfter() must be an ' .
-                       'instance of DateInterval or of the type integer, %s given';
-            $error = sprintf($message, get_class($this), gettype($time));
+            try {
+                $this->expiration = Clock::after($time);
+            } catch (\InvalidArgumentException $e) {
+                $message = 'Argument 1 passed to %s::expiresAfter() must be an ' .
+                           'instance of DateInterval or of the type integer, %s given';
+                $error = sprintf($message, get_class($this), gettype($time));
 
-            $this->handleError($error);
+                $this->handleError($error);
+            }
         }
 
         return $this;

--- a/tests/Cache/MemoryCacheItemPoolTest.php
+++ b/tests/Cache/MemoryCacheItemPoolTest.php
@@ -23,6 +23,7 @@ use Psr\Cache\InvalidArgumentException;
 
 class MemoryCacheItemPoolTest extends TestCase
 {
+    /** @var MemoryCacheItemPool */
     private $pool;
 
     public function setUp()


### PR DESCRIPTION
Hello,

During the latest DST shift we had in Europe on 28th October we experienced problems with our long-running processes failing to authenticate with GCP PubSub.

I think it was caused by a comparison that does not take the DST into account.

I split this PR into 2 commits - the failing test that demonstrates the problem we encountered and the fix.

Since manipulating time in PHP using built-in `DateTime` classes is not possible, I introduced a clock abstraction. I don't like the singleton design of it but it seemed like the simplest way to solve the problem while also keeping BC.