### PR TITLE
Move `getClientName()` to SignBlobInterface.

### DIFF
--- a/src/Credentials/InsecureCredentials.php
+++ b/src/Credentials/InsecureCredentials.php
@@ -67,15 +67,4 @@ class InsecureCredentials implements FetchAuthTokenInterface
     {
         return $this->token;
     }
-
-    /**
-     * Get the client name. In this case, it returns an empty string.
-     *
-     * @param callable $httpHandler Not used in this implementation.
-     * @return string
-     */
-    public function getClientName(callable $httpHandler = null)
-    {
-        return '';
-    }
 }

--- a/src/Credentials/UserRefreshCredentials.php
+++ b/src/Credentials/UserRefreshCredentials.php
@@ -134,15 +134,4 @@ class UserRefreshCredentials extends CredentialsLoader
     {
         return $this->auth->getLastReceivedToken();
     }
-
-    /**
-     * Get the client name.
-     *
-     * @param callable $httpHandler Not used by this credentials type.
-     * @return string
-     */
-    public function getClientName(callable $httpHandler = null)
-    {
-        return $this->auth->getClientId();
-    }
 }

--- a/src/FetchAuthTokenInterface.php
+++ b/src/FetchAuthTokenInterface.php
@@ -52,13 +52,4 @@ interface FetchAuthTokenInterface
      * }
      */
     public function getLastReceivedToken();
-
-    /**
-     * Returns the current Client Name.
-     *
-     * @param callable $httpHandler callback which delivers psr7 request, if
-     *     one is required to obtain a client name.
-     * @return string
-     */
-    public function getClientName(callable $httpHandler = null);
 }

--- a/src/SignBlobInterface.php
+++ b/src/SignBlobInterface.php
@@ -32,4 +32,13 @@ interface SignBlobInterface extends FetchAuthTokenInterface
      * @return string The resulting signature. Value should be base64-encoded.
      */
     public function signBlob($stringToSign, $forceOpenssl = false);
+
+    /**
+     * Returns the current Client Name.
+     *
+     * @param callable $httpHandler callback which delivers psr7 request, if
+     *     one is required to obtain a client name.
+     * @return string
+     */
+    public function getClientName(callable $httpHandler = null);
 }

--- a/tests/Credentials/InsecureCredentialsTest.php
+++ b/tests/Credentials/InsecureCredentialsTest.php
@@ -43,10 +43,4 @@ class InsecureCredentialsTest extends TestCase
         $insecure = new InsecureCredentials();
         $this->assertEquals(['access_token' => ''], $insecure->getLastReceivedToken());
     }
-
-    public function testGetClientName()
-    {
-        $creds = new InsecureCredentials;
-        $this->assertEquals('', $creds->getClientName());
-    }
 }

--- a/tests/Credentials/UserRefreshCredentialsTest.php
+++ b/tests/Credentials/UserRefreshCredentialsTest.php
@@ -280,13 +280,3 @@ class URCFetchAuthTokenTest extends TestCase
         $this->assertEquals($testJson, $tokens);
     }
 }
-
-class URCGetClientNameTest extends TestCase
-{
-    public function testReturnsClientId()
-    {
-        $testJson = createURCTestJson();
-        $sa = new UserRefreshCredentials('scope/1', $testJson);
-        $this->assertEquals($testJson['client_id'], $sa->getClientName());
-    }
-}

--- a/tests/FetchAuthTokenCacheTest.php
+++ b/tests/FetchAuthTokenCacheTest.php
@@ -176,7 +176,7 @@ class FetchAuthTokenCacheTest extends BaseTest
     {
         $name = 'test@example.com';
 
-        $mockFetcher = $this->prophesize('Google\Auth\FetchAuthTokenInterface');
+        $mockFetcher = $this->prophesize('Google\Auth\SignBlobInterface');
         $mockFetcher->getClientName(null)
             ->shouldBeCalled()
             ->willReturn($name);


### PR DESCRIPTION
Fixes backwards-incompatible change in #221.