### PR TITLE
Load environment data as JSON

### DIFF
--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -66,6 +66,9 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
     public static function fromEnv()
     {
         $path = getenv(self::ENV_VAR);
+        if ($credentials = json_decode($path, true)) {
+            return $credentials;
+        }
         if (empty($path)) {
             return;
         }


### PR DESCRIPTION
When service application json key located inside Kubernetes secrets it might be useful to load them directly from there.