### PR TITLE
feat: Add getProjectId to credentials types which support it

### DIFF
--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -20,6 +20,7 @@ namespace Google\Auth\Credentials;
 use Google\Auth\CredentialsLoader;
 use Google\Auth\GetQuotaProjectInterface;
 use Google\Auth\OAuth2;
+use Google\Auth\ProjectIdProviderInterface;
 use Google\Auth\ServiceAccountSignerTrait;
 use Google\Auth\SignBlobInterface;
 use InvalidArgumentException;
@@ -57,7 +58,10 @@ use InvalidArgumentException;
  *
  *   $res = $client->get('myproject/taskqueues/myqueue');
  */
-class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInterface, GetQuotaProjectInterface
+class ServiceAccountCredentials extends CredentialsLoader implements
+    GetQuotaProjectInterface,
+    SignBlobInterface,
+    ProjectIdProviderInterface
 {
     use ServiceAccountSignerTrait;
 
@@ -74,6 +78,11 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
      * @var string
      */
     protected $quotaProject;
+
+    /*
+     * @var string|null
+     */
+    protected $projectId;
 
     /**
      * Create a new ServiceAccountCredentials.
@@ -130,6 +139,10 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
             'tokenCredentialUri' => self::TOKEN_CREDENTIAL_URI,
             'additionalClaims' => $additionalClaims,
         ]);
+
+        $this->projectId = isset($jsonKey['project_id'])
+            ? $jsonKey['project_id']
+            : null;
     }
 
     /**
@@ -165,6 +178,19 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
     public function getLastReceivedToken()
     {
         return $this->auth->getLastReceivedToken();
+    }
+
+    /**
+     * Get the project ID from the service account keyfile.
+     *
+     * Returns null if the project ID does not exist in the keyfile.
+     *
+     * @param callable $httpHandler Not used by this credentials type.
+     * @return string|null
+     */
+    public function getProjectId(callable $httpHandler = null)
+    {
+        return $this->projectId;
     }
 
     /**

--- a/src/Credentials/ServiceAccountJwtAccessCredentials.php
+++ b/src/Credentials/ServiceAccountJwtAccessCredentials.php
@@ -20,6 +20,7 @@ namespace Google\Auth\Credentials;
 use Google\Auth\CredentialsLoader;
 use Google\Auth\GetQuotaProjectInterface;
 use Google\Auth\OAuth2;
+use Google\Auth\ProjectIdProviderInterface;
 use Google\Auth\ServiceAccountSignerTrait;
 use Google\Auth\SignBlobInterface;
 
@@ -32,7 +33,10 @@ use Google\Auth\SignBlobInterface;
  * console (via 'Generate new Json Key').  It is not part of any OAuth2
  * flow, rather it creates a JWT and sends that as a credential.
  */
-class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements SignBlobInterface, GetQuotaProjectInterface
+class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
+    GetQuotaProjectInterface,
+    SignBlobInterface,
+    ProjectIdProviderInterface
 {
     use ServiceAccountSignerTrait;
 
@@ -82,6 +86,10 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements Si
             'signingAlgorithm' => 'RS256',
             'signingKey' => $jsonKey['private_key'],
         ]);
+
+        $this->projectId = isset($jsonKey['project_id'])
+            ? $jsonKey['project_id']
+            : null;
     }
 
     /**
@@ -142,6 +150,19 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements Si
     public function getLastReceivedToken()
     {
         return $this->auth->getLastReceivedToken();
+    }
+
+    /**
+     * Get the project ID from the service account keyfile.
+     *
+     * Returns null if the project ID does not exist in the keyfile.
+     *
+     * @param callable $httpHandler Not used by this credentials type.
+     * @return string|null
+     */
+    public function getProjectId(callable $httpHandler = null)
+    {
+        return $this->projectId;
     }
 
     /**

--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -23,7 +23,11 @@ use Psr\Cache\CacheItemPoolInterface;
  * A class to implement caching for any object implementing
  * FetchAuthTokenInterface
  */
-class FetchAuthTokenCache implements FetchAuthTokenInterface, SignBlobInterface, GetQuotaProjectInterface
+class FetchAuthTokenCache implements
+    FetchAuthTokenInterface,
+    GetQuotaProjectInterface,
+    SignBlobInterface,
+    ProjectIdProviderInterface
 {
     use CacheTrait;
 
@@ -151,5 +155,25 @@ class FetchAuthTokenCache implements FetchAuthTokenInterface, SignBlobInterface,
         if ($this->fetcher instanceof GetQuotaProjectInterface) {
             return $this->fetcher->getQuotaProject();
         }
+    }
+
+    /*
+     * Get the Project ID from the fetcher.
+     *
+     * @param callable $httpHandler Callback which delivers psr7 request
+     * @return string|null
+     * @throws \RuntimeException If the fetcher does not implement
+     *     `Google\Auth\ProvidesProjectIdInterface`.
+     */
+    public function getProjectId(callable $httpHandler = null)
+    {
+        if (!$this->fetcher instanceof ProjectIdProviderInterface) {
+            throw new \RuntimeException(
+                'Credentials fetcher does not implement ' .
+                'Google\Auth\ProvidesProjectIdInterface'
+            );
+        }
+
+        return $this->fetcher->getProjectId($httpHandler);
     }
 }

--- a/src/ProjectIdProviderInterface.php
+++ b/src/ProjectIdProviderInterface.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ProjectIdProviderInterface.php
+++ b/src/ProjectIdProviderInterface.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth;
+
+/**
+ * Describes a Credentials object which supports fetching the project ID.
+ */
+interface ProjectIdProviderInterface
+{
+    /**
+     * Get the project ID.
+     *
+     * @param callable $httpHandler Callback which delivers psr7 request
+     * @return string|null
+     */
+    public function getProjectId(callable $httpHandler = null);
+}

--- a/tests/Credentials/AppIdentityCredentialsTest.php
+++ b/tests/Credentials/AppIdentityCredentialsTest.php
@@ -219,6 +219,23 @@ class AppIdentityCredentialsTest extends TestCase
         ], $creds->getLastReceivedToken());
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetProjectId()
+    {
+        $this->imitateInAppEngine();
+
+        $projectId = 'foobar';
+        AppIdentityService::$applicationId = $projectId;
+        $this->assertEquals($projectId, (new AppIdentityCredentials)->getProjectId());
+    }
+
+    public function testGetProjectOutsideAppEngine()
+    {
+        $this->assertNull((new AppIdentityCredentials)->getProjectId());
+    }
+
     private function imitateInAppEngine()
     {
         // include the mock AppIdentityService class

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -34,6 +34,7 @@ function createTestJson()
         'client_email' => 'test@example.com',
         'client_id' => 'client123',
         'type' => 'service_account',
+        'project_id' => 'example_project'
     ];
 }
 
@@ -375,6 +376,16 @@ class SACGetClientNameTest extends TestCase
     }
 }
 
+class SACGetProjectIdTest extends TestCase
+{
+    public function testGetProjectId()
+    {
+        $testJson = createTestJson();
+        $sa = new ServiceAccountCredentials('scope/1', $testJson);
+        $this->assertEquals($testJson['project_id'], $sa->getProjectId());
+    }
+}
+
 class SACJwtAccessTest extends TestCase
 {
     private $privateKey;
@@ -638,5 +649,15 @@ class SACJWTGetClientNameTest extends TestCase
         $testJson = createTestJson();
         $sa = new ServiceAccountJwtAccessCredentials($testJson);
         $this->assertEquals($testJson['client_email'], $sa->getClientName());
+    }
+}
+
+class SACJWTGetProjectIdTest extends TestCase
+{
+    public function testGetProjectId()
+    {
+        $testJson = createTestJson();
+        $sa = new ServiceAccountJwtAccessCredentials($testJson);
+        $this->assertEquals($testJson['project_id'], $sa->getProjectId());
     }
 }

--- a/tests/FetchAuthTokenCacheTest.php
+++ b/tests/FetchAuthTokenCacheTest.php
@@ -201,6 +201,43 @@ class FetchAuthTokenCacheTest extends BaseTest
             $this->mockCache
         );
 
-        $this->assertEquals($signature, $fetcher->signBlob('test'));
+        $fetcher->signBlob('test');
+    }
+
+    public function testGetProjectId()
+    {
+        $projectId = 'foobar';
+
+        $mockFetcher = $this->prophesize('Google\Auth\ProjectIdProviderInterface');
+        $mockFetcher->willImplement('Google\Auth\FetchAuthTokenInterface');
+        $mockFetcher->getProjectId(null)
+            ->shouldBeCalled()
+            ->willReturn($projectId);
+
+        $fetcher = new FetchAuthTokenCache(
+            $mockFetcher->reveal(),
+            [],
+            $this->mockCache->reveal()
+        );
+
+        $this->assertEquals($projectId, $fetcher->getProjectId());
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testGetProjectIdInvalidFetcher()
+    {
+        $mockFetcher = $this->prophesize('Google\Auth\FetchAuthTokenInterface');
+        $mockFetcher->getProjectId()
+            ->shouldNotbeCalled();
+
+        $fetcher = new FetchAuthTokenCache(
+            $mockFetcher->reveal(),
+            [],
+            $this->mockCache
+        );
+
+        $fetcher->getProjectId();
     }
 }

--- a/tests/mocks/AppIdentityService.php
+++ b/tests/mocks/AppIdentityService.php
@@ -10,6 +10,7 @@ class AppIdentityService
         'expiration_time' => '2147483646',
     ];
     public static $serviceAccountName;
+    public static $applicationId;
 
     public static function getAccessToken($scope)
     {
@@ -28,5 +29,10 @@ class AppIdentityService
     public static function getServiceAccountName()
     {
         return self::$serviceAccountName;
+    }
+
+    public static function getApplicationId()
+    {
+        return self::$applicationId;
     }
 }


### PR DESCRIPTION
Like a cross between #221 and #220. Provides for detection of a project ID on a Credentials instance.

Tested on GAE Standard 5.5 and 7.2 and Flex (which uses GCECredentials).

Closes #135.