### PR TITLE
Add a Metadata-Flavor HTTP header to the initial metadata request

### DIFF
--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -189,7 +189,11 @@ class GCECredentials extends CredentialsLoader implements SignBlobInterface
                 // the metadata resolution was particularly slow. The latter case is
                 // "unlikely".
                 $resp = $httpHandler(
-                    new Request('GET', $checkUri),
+                    new Request(
+                        'GET',
+                        $checkUri,
+                        [self::FLAVOR_HEADER => 'Google']
+                    ),
                     ['timeout' => self::COMPUTE_PING_CONNECTION_TIMEOUT_S]
                 );
 
@@ -340,7 +344,7 @@ class GCECredentials extends CredentialsLoader implements SignBlobInterface
             new Request(
                 'GET',
                 $uri,
-                [GCECredentials::FLAVOR_HEADER => 'Google']
+                [self::FLAVOR_HEADER => 'Google']
             )
         );
 

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -30,6 +30,20 @@ use Prophecy\Argument;
  */
 class GCECredentialsTest extends TestCase
 {
+    public function testOnGceMetadataFlavorHeader()
+    {
+        $hasHeader = false;
+        $dummyHandler = function ($request) use (&$hasHeader) {
+            $hasHeader = $request->getHeaderLine(GCECredentials::FLAVOR_HEADER) === 'Google';
+
+            return new Psr7\Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']);
+        };
+
+        $onGce = GCECredentials::onGce($dummyHandler);
+        $this->assertTrue($hasHeader);
+        $this->assertTrue($onGce);
+    }
+
     public function testOnGCEIsFalseOnClientErrorStatus()
     {
         // simulate retry attempts by returning multiple 400s


### PR DESCRIPTION
An attempt to fix https://github.com/googleapis/google-auth-library-php/issues/231