### PR TITLE
Update changelog for 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.5.2 (07/22/2019)
 
+* [fix] Move loadItems call out of `SysVCacheItemPool` constructor. (#229)
 * [fix] Add `Metadata-Flavor` header to initial GCE metadata call. (#232)
 
 ## 1.5.1 (04/16/2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.2 (07/22/2019)
+
+* [fix] Add `Metadata-Flavor` header to initial GCE metadata call. (#232)
+
 ## 1.5.1 (04/16/2019)
 
 * [fix] Moved `getClientName()` from `Google\Auth\FetchAuthTokenInterface`


### PR DESCRIPTION
## 1.5.2 (07/22/2019)

* [fix] Move loadItems call out of `SysVCacheItemPool` constructor. (#229)
* [fix] Add `Metadata-Flavor` header to initial GCE metadata call. (#232)