### PR TITLE
feat: Support custom scopes on GCECredentials

### DIFF
--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -161,7 +161,7 @@ class ApplicationDefaultCredentials
         } elseif (AppIdentityCredentials::onAppEngine() && !GCECredentials::onAppEngineFlexible()) {
             $creds = new AppIdentityCredentials($scope);
         } elseif (GCECredentials::onGce($httpHandler)) {
-            $creds = new GCECredentials();
+            $creds = new GCECredentials(null, $scope);
         }
 
         if (is_null($creds)) {


### PR DESCRIPTION
This change adds support for custom scopes provided to GCECredentials, closes #238.

This change has been verified in Cloud Run. Note that as [documented](https://cloud.google.com/run/docs/securing/service-identity#access_tokens), the feature is available only in certain limited environments, including App Engine, Run and Functions. The App Engine context, in my testing, does not appear to be inclusive of the Flex environment.