### PR TITLE
feat: Allow passthrough of configuration options to underlying HTTP client

### DIFF
--- a/src/Credentials/AppIdentityCredentials.php
+++ b/src/Credentials/AppIdentityCredentials.php
@@ -103,14 +103,17 @@ class AppIdentityCredentials extends CredentialsLoader implements SignBlobInterf
      * As the AppIdentityService uses protobufs to fetch the access token,
      * the GuzzleHttp\ClientInterface instance passed in will not be used.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     *        Unused by this implementation.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client. Unused by this implementation.
      *
      * @return array A set of auth related metadata, containing the following
      *     keys:
      *         - access_token (string)
      *         - expiration_time (string)
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(callable $httpHandler = null, array $httpOptions = [])
     {
         try {
             $this->checkAppEngineContext();
@@ -133,11 +136,18 @@ class AppIdentityCredentials extends CredentialsLoader implements SignBlobInterf
      * @param string $stringToSign The string to sign.
      * @param bool $forceOpenSsl [optional] Does not apply to this credentials
      *        type.
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      * @return string The signature, base64-encoded.
      * @throws \Exception If AppEngine SDK or mock is not available.
      */
-    public function signBlob($stringToSign, $forceOpenSsl = false)
-    {
+    public function signBlob(
+        $stringToSign,
+        $forceOpenSsl = false,
+        callable $httpHandler = null,
+        array $httpOptions = []
+    ) {
         $this->checkAppEngineContext();
 
         return base64_encode(AppIdentityService::signForApp($stringToSign)['signature']);
@@ -148,11 +158,14 @@ class AppIdentityCredentials extends CredentialsLoader implements SignBlobInterf
      *
      * Subsequent calls to this method will return a cached value.
      *
-     * @param callable $httpHandler Not used in this implementation.
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     *        Unused by this implementation.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client. Unused by this implementation.
      * @return string
      * @throws \Exception If AppEngine SDK or mock is not available.
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(callable $httpHandler = null, array $httpOptions = [])
     {
         $this->checkAppEngineContext();
 

--- a/src/Credentials/InsecureCredentials.php
+++ b/src/Credentials/InsecureCredentials.php
@@ -36,12 +36,15 @@ class InsecureCredentials implements FetchAuthTokenInterface
     /**
      * Fetches the auth token. In this case it returns an empty string.
      *
-     * @param callable $httpHandler
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     *        Unused by this implementation.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client. Unused by this implementation.
      * @return array A set of auth related metadata, containing the following
      * keys:
      *   - access_token (string)
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(callable $httpHandler = null, array $httpOptions = [])
     {
         return $this->token;
     }

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -110,7 +110,9 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
     }
 
     /**
-     * @param callable $httpHandler
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      *
      * @return array A set of auth related metadata, containing the following
      * keys:
@@ -118,9 +120,9 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
      *   - expires_in (int)
      *   - token_type (string)
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(callable $httpHandler = null, array $httpOptions = [])
     {
-        return $this->auth->fetchAuthToken($httpHandler);
+        return $this->auth->fetchAuthToken($httpHandler, $httpOptions);
     }
 
     /**
@@ -149,19 +151,27 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
      *
      * @param array $metadata metadata hashmap
      * @param string $authUri optional auth uri
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      *
      * @return array updated metadata hashmap
      */
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        callable $httpHandler = null,
+        array $httpOptions = []
     ) {
         // scope exists. use oauth implementation
         $scope = $this->auth->getScope();
         if (!is_null($scope)) {
-            return parent::updateMetadata($metadata, $authUri, $httpHandler);
+            return parent::updateMetadata(
+                $metadata,
+                $authUri,
+                $httpHandler,
+                $httpOptions
+            );
         }
 
         // no scope found. create jwt with the auth uri
@@ -171,7 +181,12 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
         );
         $jwtCreds = new ServiceAccountJwtAccessCredentials($credJson);
 
-        return $jwtCreds->updateMetadata($metadata, $authUri, $httpHandler);
+        return $jwtCreds->updateMetadata(
+            $metadata,
+            $authUri,
+            $httpHandler,
+            $httpOptions
+        );
     }
 
     /**
@@ -188,10 +203,13 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
      *
      * In this case, it returns the keyfile's client_email key.
      *
-     * @param callable $httpHandler Not used by this credentials type.
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     *        Unused by this implementation.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client. Unused by this implementation.
      * @return string
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(callable $httpHandler = null, array $httpOptions = [])
     {
         return $this->auth->getIssuer();
     }

--- a/src/Credentials/ServiceAccountJwtAccessCredentials.php
+++ b/src/Credentials/ServiceAccountJwtAccessCredentials.php
@@ -80,14 +80,17 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements Si
      *
      * @param array $metadata metadata hashmap
      * @param string $authUri optional auth uri
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      *
      * @return array updated metadata hashmap
      */
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        callable $httpHandler = null,
+        array $httpOptions = []
     ) {
         if (empty($authUri)) {
             return $metadata;
@@ -95,19 +98,27 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements Si
 
         $this->auth->setAudience($authUri);
 
-        return parent::updateMetadata($metadata, $authUri, $httpHandler);
+        return parent::updateMetadata(
+            $metadata,
+            $authUri,
+            $httpHandler,
+            $httpOptions
+        );
     }
 
     /**
      * Implements FetchAuthTokenInterface#fetchAuthToken.
      *
-     * @param callable $httpHandler
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     *        Unused by this implementation.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client. Unused by this implementation.
      *
      * @return array|void A set of auth related metadata, containing the
      * following keys:
      *   - access_token (string)
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(callable $httpHandler = null, array $httpOptions = [])
     {
         $audience = $this->auth->getAudience();
         if (empty($audience)) {
@@ -140,10 +151,13 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements Si
      *
      * In this case, it returns the keyfile's client_email key.
      *
-     * @param callable $httpHandler Not used by this credentials type.
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     *        Unused by this implementation.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client. Unused by this implementation.
      * @return string
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(callable $httpHandler = null, array $httpOptions = [])
     {
         return $this->auth->getIssuer();
     }

--- a/src/Credentials/UserRefreshCredentials.php
+++ b/src/Credentials/UserRefreshCredentials.php
@@ -104,7 +104,9 @@ class UserRefreshCredentials extends CredentialsLoader
     }
 
     /**
-     * @param callable $httpHandler
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      *
      * @return array A set of auth related metadata, containing the following
      * keys:
@@ -114,9 +116,9 @@ class UserRefreshCredentials extends CredentialsLoader
      *   - token_type (string)
      *   - id_token (string)
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(callable $httpHandler = null, array $httpOptions = [])
     {
-        return $this->auth->fetchAuthToken($httpHandler);
+        return $this->auth->fetchAuthToken($httpHandler, $httpOptions);
     }
 
     /**

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -134,7 +134,7 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
      * Create an authorized HTTP Client from an instance of FetchAuthTokenInterface.
      *
      * @param FetchAuthTokenInterface $fetcher is used to fetch the auth token
-     * @param array $httpClientOptoins (optional) Array of request options to apply.
+     * @param array $httpClientOptions (optional) Array of request options to apply.
      * @param callable $httpHandler (optional) http client to fetch the token.
      * @param callable $tokenCallback (optional) function to be called when a new token is fetched.
      *
@@ -202,16 +202,19 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
      *
      * @param array $metadata metadata hashmap
      * @param string $authUri optional auth uri
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      *
      * @return array updated metadata hashmap
      */
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        callable $httpHandler = null,
+        array $httpOptions = []
     ) {
-        $result = $this->fetchAuthToken($httpHandler);
+        $result = $this->fetchAuthToken($httpHandler, $httpOptions);
         if (!isset($result['access_token'])) {
             return $metadata;
         }

--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -61,13 +61,15 @@ class FetchAuthTokenCache implements FetchAuthTokenInterface, SignBlobInterface
      * Checks the cache for a valid auth token and fetches the auth tokens
      * from the supplied fetcher.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      *
      * @return array the response
      *
      * @throws \Exception
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(callable $httpHandler = null, array $httpOptions = [])
     {
         // Use the cached value if its available.
         //
@@ -81,7 +83,7 @@ class FetchAuthTokenCache implements FetchAuthTokenInterface, SignBlobInterface
             return ['access_token' => $cached];
         }
 
-        $auth_token = $this->fetcher->fetchAuthToken($httpHandler);
+        $auth_token = $this->fetcher->fetchAuthToken($httpHandler, $httpOptions);
 
         if (isset($auth_token['access_token'])) {
             $this->setCachedValue($cacheKey, $auth_token['access_token']);
@@ -109,27 +111,36 @@ class FetchAuthTokenCache implements FetchAuthTokenInterface, SignBlobInterface
     /**
      * Get the client name from the fetcher.
      *
-     * @param callable $httpHandler An HTTP handler to deliver PSR7 requests.
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      * @return string
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(callable $httpHandler = null, array $httpOptions = [])
     {
-        return $this->fetcher->getClientName($httpHandler);
+        return $this->fetcher->getClientName($httpHandler, $httpOptions);
     }
 
     /**
      * Sign a blob using the fetcher.
      *
      * @param string $stringToSign The string to sign.
-     * @param bool $forceOpenssl Require use of OpenSSL for local signing. Does
+     * @param bool $forceOpenSsl Require use of OpenSSL for local signing. Does
      *        not apply to signing done using external services. **Defaults to**
      *        `false`.
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      * @return string The resulting signature.
      * @throws \RuntimeException If the fetcher does not implement
      *     `Google\Auth\SignBlobInterface`.
      */
-    public function signBlob($stringToSign, $forceOpenSsl =  false)
-    {
+    public function signBlob(
+        $stringToSign,
+        $forceOpenSsl = false,
+        callable $httpHandler = null,
+        array $httpOptions = []
+    ) {
         if (!$this->fetcher instanceof SignBlobInterface) {
             throw new \RuntimeException(
                 'Credentials fetcher does not implement ' .
@@ -137,6 +148,11 @@ class FetchAuthTokenCache implements FetchAuthTokenInterface, SignBlobInterface
             );
         }
 
-        return $this->fetcher->signBlob($stringToSign, $forceOpenSsl);
+        return $this->fetcher->signBlob(
+            $stringToSign,
+            $forceOpenSsl,
+            $httpHandler,
+            $httpOptions
+        );
     }
 }

--- a/src/FetchAuthTokenInterface.php
+++ b/src/FetchAuthTokenInterface.php
@@ -25,11 +25,13 @@ interface FetchAuthTokenInterface
     /**
      * Fetches the auth tokens based on the current state.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      *
      * @return array a hash of auth tokens
      */
-    public function fetchAuthToken(callable $httpHandler = null);
+    public function fetchAuthToken(callable $httpHandler = null, array $httpOptions = []);
 
     /**
      * Obtains a key that can used to cache the results of #fetchAuthToken.

--- a/src/Iam.php
+++ b/src/Iam.php
@@ -38,12 +38,21 @@ class Iam
     private $httpHandler;
 
     /**
-     * @param callable $httpHandler [optional] The HTTP Handler to send requests.
+     * @var array
      */
-    public function __construct(callable $httpHandler = null)
+    private $httpOptions;
+
+    /**
+     * @param callable $httpHandler [optional] A callback which delivers a PSR-7
+     *        request.
+     * @param array $httpOptions [optional] Configuration options provided to
+     *        the underlying HTTP client.
+     */
+    public function __construct(callable $httpHandler = null, array $httpOptions = [])
     {
         $this->httpHandler = $httpHandler
             ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());
+        $this->httpOptions = $httpOptions;
     }
 
     /**
@@ -91,7 +100,7 @@ class Iam
             Psr7\stream_for(json_encode($body))
         );
 
-        $res = $httpHandler($request);
+        $res = $httpHandler($request, $this->httpOptions);
         $body = json_decode((string) $res->getBody(), true);
 
         return $body['signedBlob'];

--- a/src/Middleware/AuthTokenMiddleware.php
+++ b/src/Middleware/AuthTokenMiddleware.php
@@ -39,6 +39,11 @@ class AuthTokenMiddleware
     private $httpHandler;
 
     /**
+     * @var array
+     */
+    private $httpOptions;
+
+    /**
      * @var FetchAuthTokenInterface
      */
     private $fetcher;
@@ -51,18 +56,24 @@ class AuthTokenMiddleware
     /**
      * Creates a new AuthTokenMiddleware.
      *
-     * @param FetchAuthTokenInterface $fetcher is used to fetch the auth token
-     * @param callable $httpHandler (optional) callback which delivers psr7 request
-     * @param callable $tokenCallback (optional) function to be called when a new token is fetched.
+     * @param FetchAuthTokenInterface $fetcher Used to fetch an auth token.
+     * @param callable $httpHandler (optional) A callback which delivers a PSR-7
+     *        request.
+     * @param callable $tokenCallback (optional) A function to be called when a
+     *        new token is fetched.
+     * @param array $httpOptions (optional) Configuration options provided to the
+     *        underlying HTTP client.
      */
     public function __construct(
         FetchAuthTokenInterface $fetcher,
         callable $httpHandler = null,
-        callable $tokenCallback = null
+        callable $tokenCallback = null,
+        array $httpOptions = []
     ) {
         $this->fetcher = $fetcher;
         $this->httpHandler = $httpHandler;
         $this->tokenCallback = $tokenCallback;
+        $this->httpOptions = $httpOptions;
     }
 
     /**
@@ -112,7 +123,7 @@ class AuthTokenMiddleware
      */
     private function fetchToken()
     {
-        $auth_tokens = $this->fetcher->fetchAuthToken($this->httpHandler);
+        $auth_tokens = $this->fetcher->fetchAuthToken($this->httpHandler, $this->httpOptions);
 
         if (array_key_exists('access_token', $auth_tokens)) {
             // notify the callback if applicable

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -489,17 +489,19 @@ class OAuth2 implements FetchAuthTokenInterface
     /**
      * Fetches the auth tokens based on the current state.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      *
      * @return array the response
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(callable $httpHandler = null, array $httpOptions = [])
     {
         if (is_null($httpHandler)) {
             $httpHandler = HttpHandlerFactory::build(HttpClientCache::getHttpClient());
         }
 
-        $response = $httpHandler($this->generateCredentialsRequest());
+        $response = $httpHandler($this->generateCredentialsRequest(), $httpOptions);
         $credentials = $this->parseTokenResponse($response);
         $this->updateToken($credentials);
 

--- a/src/ServiceAccountSignerTrait.php
+++ b/src/ServiceAccountSignerTrait.php
@@ -28,16 +28,24 @@ trait ServiceAccountSignerTrait
      * Sign a string using the service account private key.
      *
      * @param string $stringToSign
-     * @param bool $forceOpenssl Whether to use OpenSSL regardless of
+     * @param bool $forceOpenSsl Whether to use OpenSSL regardless of
      *        whether phpseclib is installed. **Defaults to** `false`.
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     *        Unused by this implementation.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client. Unused by this implementation.
      * @return string
      */
-    public function signBlob($stringToSign, $forceOpenssl = false)
-    {
+    public function signBlob(
+        $stringToSign,
+        $forceOpenSsl = false,
+        callable $httpHandler = null,
+        array $httpOptions = []
+    ) {
         $privateKey = $this->auth->getSigningKey();
 
         $signedString = '';
-        if (class_exists('\\phpseclib\\Crypt\\RSA') && !$forceOpenssl) {
+        if (class_exists('\\phpseclib\\Crypt\\RSA') && !$forceOpenSsl) {
             $rsa = new RSA;
             $rsa->loadKey($privateKey);
             $rsa->setSignatureMode(RSA::SIGNATURE_PKCS1);

--- a/src/SignBlobInterface.php
+++ b/src/SignBlobInterface.php
@@ -26,19 +26,28 @@ interface SignBlobInterface extends FetchAuthTokenInterface
      * Sign a string using the method which is best for a given credentials type.
      *
      * @param string $stringToSign The string to sign.
-     * @param bool $forceOpenssl Require use of OpenSSL for local signing. Does
+     * @param bool $forceOpenSsl Require use of OpenSSL for local signing. Does
      *        not apply to signing done using external services. **Defaults to**
      *        `false`.
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      * @return string The resulting signature. Value should be base64-encoded.
      */
-    public function signBlob($stringToSign, $forceOpenssl = false);
+    public function signBlob(
+        $stringToSign,
+        $forceOpenSsl = false,
+        callable $httpHandler = null,
+        array $httpOptions = []
+    );
 
     /**
      * Returns the current Client Name.
      *
-     * @param callable $httpHandler callback which delivers psr7 request, if
-     *     one is required to obtain a client name.
+     * @param callable $httpHandler A callback which delivers a PSR-7 request.
+     * @param array $httpOptions Configuration options provided to the
+     *        underlying HTTP client.
      * @return string
      */
-    public function getClientName(callable $httpHandler = null);
+    public function getClientName(callable $httpHandler = null, array $httpOptions = []);
 }

--- a/src/Subscriber/AuthTokenSubscriber.php
+++ b/src/Subscriber/AuthTokenSubscriber.php
@@ -41,6 +41,11 @@ class AuthTokenSubscriber implements SubscriberInterface
     private $httpHandler;
 
     /**
+     * @var array
+     */
+    private $httpOptions;
+
+    /**
      * @var FetchAuthTokenInterface
      */
     private $fetcher;
@@ -54,17 +59,23 @@ class AuthTokenSubscriber implements SubscriberInterface
      * Creates a new AuthTokenSubscriber.
      *
      * @param FetchAuthTokenInterface $fetcher is used to fetch the auth token
-     * @param callable $httpHandler (optional) http client to fetch the token.
-     * @param callable $tokenCallback (optional) function to be called when a new token is fetched.
+     * @param callable $httpHandler (optional) A callback which delivers a PSR-7
+     *        request.
+     * @param callable $tokenCallback (optional) A function to be called when a
+     *        new token is fetched.
+     * @param array $httpOptions (optional) Configuration options provided to the
+     *        underlying HTTP client.
      */
     public function __construct(
         FetchAuthTokenInterface $fetcher,
         callable $httpHandler = null,
-        callable $tokenCallback = null
+        callable $tokenCallback = null,
+        array $httpOptions = []
     ) {
         $this->fetcher = $fetcher;
         $this->httpHandler = $httpHandler;
         $this->tokenCallback = $tokenCallback;
+        $this->httpOptions = $httpOptions;
     }
 
     /**
@@ -105,7 +116,7 @@ class AuthTokenSubscriber implements SubscriberInterface
         }
 
         // Fetch the auth token.
-        $auth_tokens = $this->fetcher->fetchAuthToken($this->httpHandler);
+        $auth_tokens = $this->fetcher->fetchAuthToken($this->httpHandler, $this->httpOptions);
         if (array_key_exists('access_token', $auth_tokens)) {
             $request->setHeader('authorization', 'Bearer ' . $auth_tokens['access_token']);
 

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -21,9 +21,11 @@ use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\Credentials\ServiceAccountCredentials;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
 
-class ADCGetTest extends TestCase
+class ADCGetCredentialsTest extends TestCase
 {
     private $originalHome;
 
@@ -101,6 +103,26 @@ class ADCGetTest extends TestCase
         $this->assertNotNull(
             ApplicationDefaultCredentials::getCredentials('a scope', $httpHandler)
         );
+    }
+
+    public function testAcceptsHttpOptions()
+    {
+        $httpOptions = ['proxy' => 'xxx.xxx.xxx.xxx'];
+        $called = false;
+        $httpHandler = function (RequestInterface $request, array $options = []) use ($httpOptions, &$called) {
+            $called = true;
+            $this->assertEquals($httpOptions + ['timeout' => 0.5], $options);
+            return new Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']);
+        };
+        $credentials = ApplicationDefaultCredentials::getCredentials(
+            'a scope',
+            $httpHandler,
+            null,
+            null,
+            $httpOptions
+        );
+
+        $this->assertTrue($called);
     }
 }
 

--- a/tests/Credentials/UserRefreshCredentialsTest.php
+++ b/tests/Credentials/UserRefreshCredentialsTest.php
@@ -279,4 +279,27 @@ class URCFetchAuthTokenTest extends TestCase
         $tokens = $sa->fetchAuthToken($httpHandler);
         $this->assertEquals($testJson, $tokens);
     }
+
+    public function testFetchAuthTokenAcceptsHttpOptions()
+    {
+        $httpOptions = ['proxy' => 'xxx.xxx.xxx.xxx'];
+        $mockOauth2 = $this->getMockBuilder('Google\Auth\OAuth2')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockOauth2->method('fetchAuthToken')
+            ->with(
+                null,
+                $httpOptions
+            )
+            ->willReturn(['access_token' => 'abc']);
+        $class = new \ReflectionClass('Google\Auth\Credentials\UserRefreshCredentials');
+        $property = $class->getProperty('auth');
+        $property->setAccessible(true);
+        $sa = new UserRefreshCredentials(
+            ['scope/1', 'scope/2'],
+            createURCTestJson()
+        );
+        $property->setValue($sa, $mockOauth2);
+        $sa->fetchAuthToken(null, $httpOptions);
+    }
 }

--- a/tests/IamTest.php
+++ b/tests/IamTest.php
@@ -34,6 +34,7 @@ class IamTest extends TestCase
         $expectedEmail = 'test@test.com';
         $expectedAccessToken = 'token';
         $expectedString = 'toSign';
+        $httpOptions = ['proxy' => 'xxx.xxx.xxx.xxx'];
 
         $expectedServiceAccount = sprintf(Iam::SERVICE_ACCOUNT_NAME, $expectedEmail);
         $expectedUri = Iam::IAM_API_ROOT . '/' . sprintf(
@@ -52,15 +53,17 @@ class IamTest extends TestCase
             $expectedDelegates[] = $expectedServiceAccount;
         }
 
-        $httpHandler = function (Psr7\Request $request) use (
+        $httpHandler = function (Psr7\Request $request, array $options = []) use (
             $expectedEmail,
             $expectedAccessToken,
             $expectedString,
             $expectedServiceAccount,
             $expectedUri,
             $expectedResponse,
-            $expectedDelegates
+            $expectedDelegates,
+            $httpOptions
         ) {
+            $this->assertEquals($httpOptions, $options);
             $this->assertEquals($expectedUri, (string) $request->getUri());
             $this->assertEquals('Bearer ' . $expectedAccessToken, $request->getHeaderLine('Authorization'));
             $this->assertEquals([
@@ -73,7 +76,7 @@ class IamTest extends TestCase
             ])));
         };
 
-        $iam = new Iam($httpHandler);
+        $iam = new Iam($httpHandler, $httpOptions);
         $res = $iam->signBlob(
             $expectedEmail,
             $expectedAccessToken,

--- a/tests/Middleware/AuthTokenMiddlewareTest.php
+++ b/tests/Middleware/AuthTokenMiddlewareTest.php
@@ -52,6 +52,28 @@ class AuthTokenMiddlewareTest extends BaseTest
                 ->getMock();
     }
 
+    public function testAcceptsHttpOptions()
+    {
+        $httpOptions = ['proxy' => 'xxx.xxx.xxx.xxx'];
+        $this->mockFetcher
+            ->expects($this->any())
+            ->method('fetchAuthToken')
+            ->with(
+                null,
+                $httpOptions
+            )
+            ->will($this->returnValue([]));
+        $this->mockRequest
+            ->expects($this->once())
+            ->method('withHeader')
+            ->will($this->returnValue($this->mockRequest));
+
+        $middleware = new AuthTokenMiddleware($this->mockFetcher, null, null, $httpOptions);
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'google_auth']);
+    }
+
     public function testOnlyTouchesWhenAuthConfigScoped()
     {
         $this->mockFetcher

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -20,6 +20,7 @@ namespace Google\Auth\Tests;
 use Google\Auth\OAuth2;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
 
 class OAuth2AuthorizationUriTest extends TestCase
@@ -772,6 +773,18 @@ class OAuth2FetchAuthTokenTest extends TestCase
         $this->assertEquals('an_access_token', $o->getAccessToken());
         $this->assertEquals('an_id_token', $o->getIdToken());
         $this->assertEquals('a_refresh_token', $o->getRefreshToken());
+    }
+
+    public function testFetchAuthTokenAcceptsHttpOptions()
+    {
+        $httpOptions = ['proxy' => 'xxx.xxx.xxx.xxx'];
+        $testConfig = $this->fetchAuthTokenMinimal;
+        $httpHandler = function (RequestInterface $request, array $options = []) use ($httpOptions) {
+            $this->assertEquals($httpOptions, $options);
+            return new Response(200, [], '{"access_token":"abc"}');
+        };
+        $o = new OAuth2($testConfig);
+        $o->fetchAuthToken($httpHandler, $httpOptions);
     }
 }
 

--- a/tests/Subscriber/AuthTokenSubscriberTest.php
+++ b/tests/Subscriber/AuthTokenSubscriberTest.php
@@ -53,6 +53,33 @@ class AuthTokenSubscriberTest extends BaseTest
         $this->assertArrayHasKey('before', $a->getEvents());
     }
 
+    public function testAcceptsHttpOptionz()
+    {
+        $httpOptions = ['proxy' => 'xxx.xxx.xxx.xxx'];
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('fetchAuthToken')
+            ->with(
+                null,
+                $httpOptions
+            )
+            ->will($this->returnValue([]));
+        $a = new AuthTokenSubscriber(
+            $this->mockFetcher,
+            null,
+            null,
+            $httpOptions
+        );
+        $client = new Client();
+        $request = $client->createRequest(
+            'GET',
+            'http://testing.org',
+            ['auth' => 'google_auth']
+        );
+        $before = new BeforeEvent(new Transaction($client, $request));
+        $a->onBefore($before);
+    }
+
     public function testOnlyTouchesWhenAuthConfigScoped()
     {
         $s = new AuthTokenSubscriber($this->mockFetcher);


### PR DESCRIPTION
Towards: https://github.com/googleapis/google-cloud-php/issues/1268