### PR TITLE
feat: Add Verify and Revoke token functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,18 +7,18 @@
   "license": "Apache-2.0",
   "require": {
     "php": ">=5.4",
-    "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",
+    "firebase/php-jwt": "~3.0|~4.0|~5.0",
     "guzzlehttp/guzzle": "~5.3.1|~6.0",
     "guzzlehttp/psr7": "^1.2",
     "psr/http-message": "^1.0",
-    "psr/cache": "^1.0"
+    "psr/cache": "^1.0",
+    "phpseclib/phpseclib": "^2"
   },
   "require-dev": {
     "guzzlehttp/promises": "0.1.1|^1.3",
     "friendsofphp/php-cs-fixer": "^1.11",
     "phpunit/phpunit": "^4.8.36|^5.7",
-    "sebastian/comparator": ">=1.2.3",
-    "phpseclib/phpseclib": "^2"
+    "sebastian/comparator": ">=1.2.3"
   },
   "suggest": {
     "phpseclib/phpseclib": "May be used in place of OpenSSL for signing strings. Please require version ^2."

--- a/composer.json
+++ b/composer.json
@@ -7,21 +7,21 @@
   "license": "Apache-2.0",
   "require": {
     "php": ">=5.4",
-    "firebase/php-jwt": "~3.0|~4.0|~5.0",
+    "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",
     "guzzlehttp/guzzle": "~5.3.1|~6.0",
     "guzzlehttp/psr7": "^1.2",
     "psr/http-message": "^1.0",
-    "psr/cache": "^1.0",
-    "phpseclib/phpseclib": "^2"
+    "psr/cache": "^1.0"
   },
   "require-dev": {
     "guzzlehttp/promises": "0.1.1|^1.3",
     "friendsofphp/php-cs-fixer": "^1.11",
     "phpunit/phpunit": "^4.8.36|^5.7",
-    "sebastian/comparator": ">=1.2.3"
+    "sebastian/comparator": ">=1.2.3",
+    "phpseclib/phpseclib": "^2"
   },
   "suggest": {
-    "phpseclib/phpseclib": "May be used in place of OpenSSL for signing strings. Please require version ^2."
+    "phpseclib/phpseclib": "May be used in place of OpenSSL for signing strings or for token management. Please require version ^2."
   },
   "autoload": {
     "psr-4": {

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -1,0 +1,281 @@
+<?php
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth;
+
+use Firebase\JWT\ExpiredException;
+use Firebase\JWT\JWT;
+use Firebase\JWT\SignatureInvalidException;
+use Google\Auth\Cache\MemoryCacheItemPool;
+use Google\Auth\HttpHandler\HttpClientCache;
+use Google\Auth\HttpHandler\HttpHandlerFactory;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Request;
+use phpseclib\Crypt\RSA;
+use phpseclib\Math\BigInteger;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Wrapper around Google Access Tokens which provides convenience functions
+ */
+class AccessToken
+{
+    const FEDERATED_SIGNON_CERT_URL = 'https://www.googleapis.com/oauth2/v3/certs';
+    const OAUTH2_ISSUER = 'accounts.google.com';
+    const OAUTH2_ISSUER_HTTPS = 'https://accounts.google.com';
+    const OAUTH2_REVOKE_URI = 'https://oauth2.googleapis.com/revoke';
+
+    /**
+     * @var callable
+     */
+    private $httpHandler;
+
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    /**
+     * @param callable $httpHandler [optional] An HTTP Handler to deliver PSR-7 requests.
+     * @param CacheItemPoolInterface $cache [optional] A PSR-6 compatible cache implementation.
+     */
+    public function __construct(
+        callable $httpHandler = null,
+        CacheItemPoolInterface $cache = null
+    ) {
+        $this->httpHandler = $httpHandler
+            ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());
+        $this->cache = $cache ?: new MemoryCacheItemPool();
+        $this->configureJwtService();
+
+        // set phpseclib constants if applicable
+        $this->setPhpsecConstants();
+    }
+
+    /**
+     * Verifies an id token and returns the authenticated apiLoginTicket.
+     * Throws an exception if the id token is not valid.
+     * The audience parameter can be used to control which id tokens are
+     * accepted.  By default, the id token must have been issued to this OAuth2 client.
+     *
+     * @param string $token The JSON Web Token to be verified.
+     * @param string $audience [optional] The indended recipient of the token.
+     * @param string $certsLocation [optional] The location (remote or local)
+     *        from which to retrieve certificates, if not cached. This value
+     *        should only be provided in limited circumstances in which you are
+     *        sure of the behavior.
+     * @return array|bool the token payload, if successful, or false if not.
+     */
+    public function verify($token, $audience = null, $certsLocation = null)
+    {
+        // Check signature against each available cert.
+        // allow the loop to complete unless a known bad result is encountered.
+        $certs = $this->getFederatedSignOnCerts($certsLocation);
+        foreach ($certs as $cert) {
+            $rsa = new RSA();
+            $rsa->loadKey([
+                'n' => new BigInteger($this->callJwtStatic('urlsafeB64Decode', [
+                    $cert['n']
+                ]), 256),
+                'e' => new BigInteger($this->callJwtStatic('urlsafeB64Decode', [
+                    $cert['e']
+                ]), 256)
+            ]);
+
+            try {
+                $pubkey = $rsa->getPublicKey();
+                $payload = $this->callJwtStatic('decode', [
+                    $token,
+                    $pubkey,
+                    ['RS256']
+                ]);
+
+                if (property_exists($payload, 'aud')) {
+                    if ($audience && $payload->aud != $audience) {
+                        return false;
+                    }
+                }
+
+                // support HTTP and HTTPS issuers
+                // @see https://developers.google.com/identity/sign-in/web/backend-auth
+                $issuers = array(self::OAUTH2_ISSUER, self::OAUTH2_ISSUER_HTTPS);
+                if (!isset($payload->iss) || !in_array($payload->iss, $issuers)) {
+                    return false;
+                }
+
+                return (array) $payload;
+            } catch (ExpiredException $e) {
+                return false;
+            } catch (SignatureInvalidException $e) {
+                // continue
+            } catch (\DomainException $e) {
+                // continue
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Revoke an OAuth2 access token or refresh token. This method will revoke the current access
+     * token, if a token isn't provided.
+     *
+     * @param string|array $token The token (access token or a refresh token) that should be revoked.
+     * @return boolean Returns True if the revocation was successful, otherwise False.
+     */
+    public function revoke($token)
+    {
+        if (is_array($token)) {
+            if (isset($token['refresh_token'])) {
+                $token = $token['refresh_token'];
+            } else {
+                $token = $token['access_token'];
+            }
+        }
+
+        $body = Psr7\stream_for(http_build_query(['token' => $token]));
+        $request = new Request('POST', self::OAUTH2_REVOKE_URI, [
+            'Cache-Control' => 'no-store',
+            'Content-Type'  => 'application/x-www-form-urlencoded',
+        ], $body);
+
+        $httpHandler = $this->httpHandler;
+
+        $response = $httpHandler($request);
+
+        return $response->getStatusCode() == 200;
+    }
+
+    /**
+     * Gets federated sign-on certificates to use for verifying identity tokens.
+     * Returns certs as array structure, where keys are key ids, and values
+     * are PEM encoded certificates.
+     *
+     * @param string $location [optional] The location from which to retrieve
+     *        certs.
+     * @return array
+     */
+    private function getFederatedSignOnCerts($location = null)
+    {
+        $cacheItem = $this->cache->getItem('federated_signon_certs_v3');
+        $certs = $cacheItem ? $cacheItem->get() : null;
+
+        $gotNewCerts = false;
+        if (!$certs) {
+            $certs = $this->retrieveCertsFromLocation(
+                $location ?: self::FEDERATED_SIGNON_CERT_URL
+            );
+
+            $gotNewCerts = true;
+        }
+
+        if (!isset($certs['keys'])) {
+            throw new \InvalidArgumentException(
+                'federated sign-on certs expects "keys" to be set'
+            );
+        }
+
+        // Push cacheing off until after verifying certs are in a valid format.
+        // Don't want to cache bad data.
+        if ($gotNewCerts) {
+            $cacheItem->expiresAt(new \DateTime('+1 hour'));
+            $cacheItem->set($certs);
+            $this->cache->save($cacheItem);
+        }
+
+        return $certs['keys'];
+    }
+
+    /**
+     * Retrieve and cache a certificates file.
+     *
+     * @param $url string location
+     * @throws \RuntimeException
+     * @return array certificates
+     */
+    private function retrieveCertsFromLocation($url)
+    {
+        // If we're retrieving a local file, just grab it.
+        if (strpos($url, 'http') !== 0) {
+            if (!file_exists($url)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Failed to retrieve verification certificates from path: %s.',
+                    $url
+                ));
+            }
+
+            return json_decode(file_get_contents($url), true);
+        }
+
+        $httpHandler = $this->httpHandler;
+        $response = $httpHandler(new Request('GET', $url));
+
+        if ($response->getStatusCode() == 200) {
+            return json_decode((string) $response->getBody(), true);
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Failed to retrieve verification certificates: "%s".',
+            $response->getBody()->getContents()
+        ), $response->getStatusCode());
+    }
+
+    /**
+     * Set required defaults for JWT.
+     */
+    private function configureJwtService()
+    {
+        if (property_exists('Firebase\JWT\JWT', 'leeway') && JWT::$leeway < 1) {
+            // Ensures JWT leeway is at least 1
+            // @see https://github.com/google/google-api-php-client/issues/827
+            JWT::$leeway = 1;
+        }
+    }
+
+    /**
+     * phpseclib calls "phpinfo" by default, which requires special
+     * whitelisting in the AppEngine VM environment. This function
+     * sets constants to bypass the need for phpseclib to check phpinfo
+     *
+     * @see phpseclib/Math/BigInteger
+     * @see https://github.com/GoogleCloudPlatform/getting-started-php/issues/85
+     * @codeCoverageIgnore
+     */
+    private function setPhpsecConstants()
+    {
+        if (filter_var(getenv('GAE_VM'), FILTER_VALIDATE_BOOLEAN)) {
+            if (!defined('MATH_BIGINTEGER_OPENSSL_ENABLED')) {
+                define('MATH_BIGINTEGER_OPENSSL_ENABLED', true);
+            }
+            if (!defined('CRYPT_RSA_MODE')) {
+                define('CRYPT_RSA_MODE', RSA::MODE_OPENSSL);
+            }
+        }
+    }
+
+    /**
+     * Provide a hook to mock calls to the JWT static methods.
+     *
+     * @param string $method
+     * @param array $args
+     * @return mixed
+     */
+    protected function callJwtStatic($method, array $args = [])
+    {
+        return call_user_func_array(['Firebase\JWT\JWT', $method], $args);
+    }
+}

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -134,7 +134,7 @@ class AccessToken
                 // continue
             } catch (\SignatureInvalidException $e) {
                 // continue (firebase/php-jwt 2)
-            }catch (\DomainException $e) {
+            } catch (\DomainException $e) {
                 // continue
             }
         }

--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -1,0 +1,385 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Tests;
+
+use Firebase\JWT\ExpiredException;
+use Firebase\JWT\JWT;
+use Firebase\JWT\SignatureInvalidException;
+use Google\Auth\AccessToken;
+use GuzzleHttp\Psr7\Response;
+use phpseclib\Crypt\RSA;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @group access-token
+ */
+class AccessTokenTest extends TestCase
+{
+    private $cache;
+    private $payload;
+
+    private $token;
+    private $publicKey;
+    private $allowedAlgs;
+
+    public function setUp()
+    {
+        $this->cache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
+        $this->jwt = $this->prophesize('Firebase\JWT\JWT');
+        $this->token = 'foobar';
+        $this->publicKey = 'barfoo';
+        $this->allowedAlgs = ['RS256'];
+
+        $this->payload = [
+            'iat' => time(),
+            'exp' => time() + 30,
+            'name' => 'foo',
+            'iss' => AccessToken::OAUTH2_ISSUER_HTTPS
+        ];
+    }
+
+    /**
+     * @dataProvider verifyCalls
+     */
+    public function testVerify(
+        $payload,
+        $expected,
+        $audience = null,
+        callable $verifyCallback = null
+    ) {
+        $item = $this->prophesize('Psr\Cache\CacheItemInterface');
+        $item->get()->willReturn([
+            'keys' => [
+                [
+                    'kid' => 'ddddffdfd',
+                    'e' => 'AQAB',
+                    'kty' => 'RSA',
+                    'alg' => 'RS256',
+                    'n' => $this->publicKey,
+                    'use' => 'sig'
+                ]
+            ]
+        ]);
+
+        $this->cache->getItem('federated_signon_certs_v3')
+            ->shouldBeCalledTimes(1)
+            ->willReturn($item->reveal());
+
+        $token = new AccessTokenStub(
+            null,
+            $this->cache->reveal(),
+            $this->jwt->reveal()
+        );
+
+        $token->mocks['decode'] = function ($token, $publicKey, $allowedAlgs) use ($payload, $verifyCallback) {
+            $this->assertEquals($this->token, $token);
+            $this->assertEquals($this->allowedAlgs, $allowedAlgs);
+
+            if ($verifyCallback) {
+                $verifyCallback($token, $publicKey, $allowedAlgs);
+            }
+
+            return (object) $payload;
+        };
+
+        $res = $token->verify($this->token, $audience);
+        $this->assertEquals($expected, $res);
+    }
+
+    public function verifyCalls()
+    {
+        $this->setUp();
+
+        return [
+            [
+                $this->payload,
+                $this->payload,
+            ], [
+                $this->payload + [
+                    'aud' => 'foo'
+                ],
+                $this->payload + [
+                    'aud' => 'foo'
+                ],
+                'foo'
+            ], [
+                $this->payload + [
+                    'aud' => 'foo'
+                ],
+                false,
+                'bar'
+            ], [
+                [
+                    'iss' => 'invalid'
+                ] + $this->payload,
+                false
+            ], [
+                $this->payload,
+                false,
+                null,
+                function () {
+                    throw new ExpiredException('expired!');
+                }
+            ], [
+                $this->payload,
+                false,
+                null,
+                function () {
+                    throw new SignatureInvalidException('expired!');
+                }
+            ], [
+                $this->payload,
+                false,
+                null,
+                function () {
+                    throw new \DomainException('expired!');
+                }
+            ]
+        ];
+    }
+
+    public function testRetrieveCertsFromLocationLocalFile()
+    {
+        $certsLocation = __DIR__ . '/fixtures/federated-certs.json';
+        $certsData = json_decode(file_get_contents($certsLocation), true);
+
+        $item = $this->prophesize('Psr\Cache\CacheItemInterface');
+        $item->get()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(null);
+        $item->set($certsData)
+            ->shouldBeCalledTimes(1);
+        $item->expiresAt(Argument::type('\DateTime'))
+            ->shouldBeCalledTimes(1);
+
+        $this->cache->getItem('federated_signon_certs_v3')
+            ->shouldBeCalledTimes(1)
+            ->willReturn($item->reveal());
+
+        $this->cache->save(Argument::type('Psr\Cache\CacheItemInterface'))
+            ->shouldBeCalledTimes(1);
+
+        $token = new AccessTokenStub(
+            null,
+            $this->cache->reveal(),
+            $this->jwt->reveal()
+        );
+
+        $token->mocks['decode'] = function ($token, $publicKey, $allowedAlgs) {
+            $this->assertEquals($this->token, $token);
+            $this->assertEquals($this->allowedAlgs, $allowedAlgs);
+
+            return (object) $this->payload;
+        };
+
+        $token->verify($this->token, null, $certsLocation);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Failed to retrieve verification certificates from path
+     */
+    public function testRetrieveCertsFromLocationLocalFileInvalidFilePath()
+    {
+        $certsLocation = __DIR__ . '/fixtures/federated-certs-does-not-exist.json';
+
+        $item = $this->prophesize('Psr\Cache\CacheItemInterface');
+        $item->get()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(null);
+
+        $this->cache->getItem('federated_signon_certs_v3')
+            ->shouldBeCalledTimes(1)
+            ->willReturn($item->reveal());
+
+        $token = new AccessTokenStub(
+            null,
+            $this->cache->reveal(),
+            $this->jwt->reveal()
+        );
+
+        $token->verify($this->token, null, $certsLocation);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage federated sign-on certs expects "keys" to be set
+     */
+    public function testRetrieveCertsFromLocationLocalFileInvalidFileData()
+    {
+        $temp = tmpfile();
+        fwrite($temp, '{}');
+        $certsLocation = stream_get_meta_data($temp)['uri'];
+
+        $item = $this->prophesize('Psr\Cache\CacheItemInterface');
+        $item->get()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(null);
+
+        $this->cache->getItem('federated_signon_certs_v3')
+            ->shouldBeCalledTimes(1)
+            ->willReturn($item->reveal());
+
+        $token = new AccessTokenStub(
+            null,
+            $this->cache->reveal(),
+            $this->jwt->reveal()
+        );
+
+        $token->verify($this->token, null, $certsLocation);
+    }
+
+    public function testRetrieveCertsFromLocationRemote()
+    {
+        $certsLocation = __DIR__ . '/fixtures/federated-certs.json';
+        $certsJson = file_get_contents($certsLocation);
+        $certsData = json_decode($certsJson, true);
+
+        $httpHandler = function (RequestInterface $request) use ($certsJson) {
+            $this->assertEquals(AccessToken::FEDERATED_SIGNON_CERT_URL, (string) $request->getUri());
+            $this->assertEquals('GET', $request->getMethod());
+
+            return new Response(200, [], $certsJson);
+        };
+
+        $item = $this->prophesize('Psr\Cache\CacheItemInterface');
+        $item->get()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(null);
+        $item->set($certsData)
+            ->shouldBeCalledTimes(1);
+        $item->expiresAt(Argument::type('\DateTime'))
+            ->shouldBeCalledTimes(1);
+
+        $this->cache->getItem('federated_signon_certs_v3')
+            ->shouldBeCalledTimes(1)
+            ->willReturn($item->reveal());
+
+        $this->cache->save(Argument::type('Psr\Cache\CacheItemInterface'))
+            ->shouldBeCalledTimes(1);
+
+        $token = new AccessTokenStub(
+            $httpHandler,
+            $this->cache->reveal(),
+            $this->jwt->reveal()
+        );
+
+        $token->mocks['decode'] = function ($token, $publicKey, $allowedAlgs) {
+            $this->assertEquals($this->token, $token);
+            $this->assertEquals($this->allowedAlgs, $allowedAlgs);
+
+            return (object) $this->payload;
+        };
+
+        $token->verify($this->token);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage bad news guys
+     */
+    public function testRetrieveCertsFromLocationRemoteBadRequest()
+    {
+        $badBody = 'bad news guys';
+
+        $httpHandler = function (RequestInterface $request) use ($badBody) {
+            return new Response(500, [], $badBody);
+        };
+
+        $item = $this->prophesize('Psr\Cache\CacheItemInterface');
+        $item->get()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(null);
+
+        $this->cache->getItem('federated_signon_certs_v3')
+            ->shouldBeCalledTimes(1)
+            ->willReturn($item->reveal());
+
+        $token = new AccessTokenStub(
+            $httpHandler,
+            $this->cache->reveal()
+        );
+
+        $token->verify($this->token);
+    }
+
+    /**
+     * @dataProvider revokeTokens
+     */
+    public function testRevoke($input, $expected)
+    {
+        $httpHandler = function (RequestInterface $request) use ($expected) {
+            $this->assertEquals('no-store', $request->getHeaderLine('Cache-Control'));
+            $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
+            $this->assertEquals('POST', $request->getMethod());
+            $this->assertEquals(AccessToken::OAUTH2_REVOKE_URI, (string) $request->getUri());
+            $this->assertEquals('token=' . $expected, (string) $request->getBody());
+
+            return new Response(200);
+        };
+
+        $token = new AccessToken($httpHandler);
+
+        $this->assertTrue($token->revoke($input));
+    }
+
+    public function revokeTokens()
+    {
+        $this->setUp();
+
+        return [
+            [
+                $this->token,
+                $this->token
+            ], [
+                ['refresh_token' => $this->token, 'access_token' => 'other thing'],
+                $this->token
+            ], [
+                ['access_token' => $this->token],
+                $this->token
+            ]
+        ];
+    }
+
+    public function testRevokeFails()
+    {
+        $httpHandler = function (RequestInterface $request) {
+            return new Response(500);
+        };
+
+        $token = new AccessToken($httpHandler);
+
+        $this->assertFalse($token->revoke($this->token));
+    }
+}
+
+//@codingStandardsIgnoreStart
+class AccessTokenStub extends AccessToken
+{
+    public $mocks = [];
+
+    protected function callJwtStatic($method, array $args = [])
+    {
+        return isset($this->mocks[$method])
+            ? call_user_func_array($this->mocks[$method], $args)
+            : parent::callJwtStatic($method, $args);
+    }
+}
+//@codingStandardsIgnoreEnd

--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -99,7 +99,9 @@ class AccessTokenTest extends TestCase
             return (object) $payload;
         };
 
-        $res = $token->verify($this->token, $audience);
+        $res = $token->verify($this->token, [
+            'audience' => $audience
+        ]);
         $this->assertEquals($expected, $res);
     }
 
@@ -197,7 +199,9 @@ class AccessTokenTest extends TestCase
             return (object) $this->payload;
         };
 
-        $token->verify($this->token, null, $certsLocation);
+        $token->verify($this->token, [
+            'certsLocation' => $certsLocation
+        ]);
     }
 
     /**
@@ -223,7 +227,9 @@ class AccessTokenTest extends TestCase
             $this->jwt->reveal()
         );
 
-        $token->verify($this->token, null, $certsLocation);
+        $token->verify($this->token, [
+            'certsLocation' => $certsLocation
+        ]);
     }
 
     /**
@@ -251,7 +257,9 @@ class AccessTokenTest extends TestCase
             $this->jwt->reveal()
         );
 
-        $token->verify($this->token, null, $certsLocation);
+        $token->verify($this->token, [
+            'certsLocation' => $certsLocation
+        ]);
     }
 
     public function testRetrieveCertsFromLocationRemote()

--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -135,14 +135,22 @@ class AccessTokenTest extends TestCase
                 false,
                 null,
                 function () {
-                    throw new ExpiredException('expired!');
+                    if (class_exists('Firebase\JWT\ExpiredException')) {
+                        throw new ExpiredException('expired!');
+                    } else {
+                        throw new \ExpiredException('expired');
+                    }
                 }
             ], [
                 $this->payload,
                 false,
                 null,
                 function () {
-                    throw new SignatureInvalidException('expired!');
+                    if (class_exists('Firebase\JWT\SignatureInvalidException')) {
+                        throw new SignatureInvalidException('invalid!');
+                    } else {
+                        throw new \SignatureInvalidException('invalid');
+                    }
                 }
             ], [
                 $this->payload,

--- a/tests/fixtures/federated-certs.json
+++ b/tests/fixtures/federated-certs.json
@@ -1,0 +1,20 @@
+{
+    "keys": [
+        {
+            "kid": "05a02649a5b45c90fdfe4da1ebefa9c079ab593e",
+            "e": "AQAB",
+            "kty": "RSA",
+            "alg": "RS256",
+            "n": "testdata-1",
+            "use": "sig"
+        },
+        {
+            "kid": "2bf8418b2963f366f5fefdd127b2cee07c887e65",
+            "e": "AQAB",
+            "kty": "RSA",
+            "alg": "RS256",
+            "n": "testdata-2",
+            "use": "sig"
+        }
+    ]
+}


### PR DESCRIPTION
This change adds JWT token verification and revokation to the PHP Auth library. It is essentially a migration of `Revoke.php` and `Verify.php` from the [API Client](https://github.com/googleapis/google-api-php-client/tree/master/src/Google/AccessToken) with some cleanup and new unit tests that don't rely on real service calls.