### PR TITLE
feat: accept json string in `GOOGLE_APPLICATION_CREDENTIALS` var

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Once downloaded, store the path to this file in the
 putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
 ```
 
+or put the contents of the file directly into the environment variable
+
+```php
+putenv('GOOGLE_APPLICATION_CREDENTIALS={"private_key_id": "key123","private_key": "privatekey","client_email": "hello@youarecool.com","client_id": "client123","type": "service_account"}');
+```
+
 > PHP's `putenv` function is just one way to set an environment variable.
 > Consider using `.htaccess` or apache configuration files as well.
 

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -69,6 +69,9 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
         if (empty($path)) {
             return;
         }
+        if(!is_null(json_decode($path, true))) {
+            return json_decode($path, true);
+        }
         if (!file_exists($path)) {
             $cause = 'file ' . $path . ' does not exist';
             throw new \DomainException(self::unableToReadEnv($cause));

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -195,6 +195,13 @@ class SACFromEnvTest extends TestCase
         putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
         $this->assertNotNull(ApplicationDefaultCredentials::getCredentials('a scope'));
     }
+
+    public function testSucceedIfEnvIsJsonString()
+    {
+        $keyFile = file_get_contents(__DIR__ . '/../fixtures' . '/private.json');
+        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $this->assertNotNull(ApplicationDefaultCredentials::getCredentials('a scope'));
+    }
 }
 
 class SACFromWellKnownFileTest extends TestCase


### PR DESCRIPTION
Add support for a string in the environment variable `GOOGLE_APPLICATION_CREDENTIALS`, in addition to support for a disk file path.

```php
putenv('GOOGLE_APPLICATION_CREDENTIALS={"private_key_id": "key123","private_key": "privatekey","client_email": "hello@youarecool.com","client_id": "client123","type": "service_account"}');
```