### PR TITLE
feat: Adds ID token to auth token methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,22 +133,23 @@ use GuzzleHttp\HandlerStack;
 // specify the path to your application credentials
 putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
 
-// Provide the target audience. This can be a Client ID associated with an IAP application,
+// Provide the ID token audience. This can be a Client ID associated with an IAP application,
 // Or the URL associated with a CloudRun App
-//    $targetAudience = 'IAP_CLIENT_ID.apps.googleusercontent.com';
-//    $targetAudience = 'https://service-1234-uc.a.run.app';
-$targetAudience = 'YOUR_TARGET_AUDIENCE';
+//    $idTokenAudience = 'IAP_CLIENT_ID.apps.googleusercontent.com';
+//    $idTokenAudience = 'https://service-1234-uc.a.run.app';
+$idTokenAudience = 'YOUR_ID_TOKEN_AUDIENCE';
 
 // create middleware
-$middleware = ApplicationDefaultCredentials::getMiddleware(null, null, null, null, $targetAudience);
+$middleware = ApplicationDefaultCredentials::getMiddleware(null, null, null, null, $idTokenAudience);
 $stack = HandlerStack::create();
 $stack->push($middleware);
 
 // create the HTTP client
 $client = new Client([
   'handler' => $stack,
-  'base_uri' => $targetAudience,
-  'auth' => 'google_auth'
+  'auth' => 'google_auth',
+  // Cloud Run, IAP, or custom resource URL
+  'base_uri' => 'https://YOUR_PROTECTED_RESOURCE',
 ]);
 
 // make the request

--- a/README.md
+++ b/README.md
@@ -133,9 +133,11 @@ use GuzzleHttp\HandlerStack;
 // specify the path to your application credentials
 putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
 
-// Provide the target audience, for example the Client ID associated with an IAP
-// application
-$targetAudience = 'IAP_CLIENT_ID.apps.googleusercontent.com';
+// Provide the target audience. This can be a Client ID associated with an IAP application,
+// Or the URL associated with a CloudRun App
+//    $targetAudience = 'IAP_CLIENT_ID.apps.googleusercontent.com';
+//    $targetAudience = 'https://service-1234-uc.a.run.app';
+$targetAudience = 'YOUR_TARGET_AUDIENCE';
 
 // create middleware
 $middleware = ApplicationDefaultCredentials::getMiddleware(null, null, null, null, $targetAudience);
@@ -145,8 +147,8 @@ $stack->push($middleware);
 // create the HTTP client
 $client = new Client([
   'handler' => $stack,
-  'base_uri' => 'https://IAP_PROJECT_ID.googleapis.com',
-  'auth' => 'google_id_token'
+  'base_uri' => $targetAudience,
+  'auth' => 'google_auth'
 ]);
 
 // make the request

--- a/README.md
+++ b/README.md
@@ -123,6 +123,38 @@ $subscriber = ApplicationDefaultCredentials::getSubscriber($scopes);
 $client->getEmitter()->attach($subscriber);
 
 ```
+#### Call using an ID Token
+
+```php
+use Google\Auth\ApplicationDefaultCredentials;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+
+// specify the path to your application credentials
+putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
+
+// Provide the target audience, for example the Client ID associated with an IAP
+// application
+$targetAudience = 'IAP_CLIENT_ID.apps.googleusercontent.com';
+
+// create middleware
+$middleware = ApplicationDefaultCredentials::getMiddleware(null, null, null, null, $targetAudience);
+$stack = HandlerStack::create();
+$stack->push($middleware);
+
+// create the HTTP client
+$client = new Client([
+  'handler' => $stack,
+  'base_uri' => 'https://IAP_PROJECT_ID.googleapis.com',
+  'auth' => 'google_id_token'
+]);
+
+// make the request
+$response = $client->get('/');
+
+// show the result!
+print_r((string) $response->getBody());
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ $client = new Client([
 // create subscriber
 $subscriber = ApplicationDefaultCredentials::getSubscriber($scopes);
 $client->getEmitter()->attach($subscriber);
-
 ```
+
 #### Call using an ID Token
 
 ```php
@@ -140,7 +140,7 @@ putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
 $targetAudience = 'YOUR_ID_TOKEN_AUDIENCE';
 
 // create middleware
-$middleware = ApplicationDefaultCredentials::getMiddleware(null, null, null, null, $targetAudience);
+$middleware = ApplicationDefaultCredentials::getIdTokenMiddleware($targetAudience);
 $stack = HandlerStack::create();
 $stack->push($middleware);
 

--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
 
 // Provide the ID token audience. This can be a Client ID associated with an IAP application,
 // Or the URL associated with a CloudRun App
-//    $idTokenAudience = 'IAP_CLIENT_ID.apps.googleusercontent.com';
-//    $idTokenAudience = 'https://service-1234-uc.a.run.app';
-$idTokenAudience = 'YOUR_ID_TOKEN_AUDIENCE';
+//    $targetAudience = 'IAP_CLIENT_ID.apps.googleusercontent.com';
+//    $targetAudience = 'https://service-1234-uc.a.run.app';
+$targetAudience = 'YOUR_ID_TOKEN_AUDIENCE';
 
 // create middleware
-$middleware = ApplicationDefaultCredentials::getMiddleware(null, null, null, null, $idTokenAudience);
+$middleware = ApplicationDefaultCredentials::getMiddleware(null, null, null, null, $targetAudience);
 $stack = HandlerStack::create();
 $stack->push($middleware);
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ $client->getEmitter()->attach($subscriber);
 ```
 
 #### Call using an ID Token
+If your application is running behind Cloud Run, or using Cloud Identity-Aware
+Proxy (IAP), you will need to fetch an ID token to access your application. For
+this, use the static method `getIdTokenMiddleware` on
+`ApplicationDefaultCredentials`.
 
 ```php
 use Google\Auth\ApplicationDefaultCredentials;
@@ -158,6 +162,14 @@ $response = $client->get('/');
 // show the result!
 print_r((string) $response->getBody());
 ```
+
+For invoking Cloud Run services, your service account will need the
+[`Cloud Run Invoker`](https://cloud.google.com/run/docs/authenticating/service-to-service)
+IAM permission.
+
+For invoking Cloud Identity-Aware Proxy, you will need to pass the Client ID
+used when you set up your protected resource as the target audience. See how to
+[secure your IAP app with signed headers](https://cloud.google.com/iap/docs/signed-headers-howto).
 
 ## License
 

--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -174,7 +174,11 @@ class ApplicationDefaultCredentials
 
         if (!is_null($jsonKey)) {
             $creds = CredentialsLoader::makeCredentials($scope, $jsonKey, $idTokenAudience);
-        } elseif (AppIdentityCredentials::onAppEngine() && !GCECredentials::onAppEngineFlexible() && is_null($idTokenAudience)) {
+        } elseif (AppIdentityCredentials::onAppEngine() && !GCECredentials::onAppEngineFlexible()) {
+            if (!empty($idTokenAudience)) {
+                throw new \InvalidArgumentException(
+                    'idTokenAudience is not valid on older versions of App Engine');
+            }
             $creds = new AppIdentityCredentials($scope);
         } elseif (GCECredentials::onGce($httpHandler)) {
             $creds = new GCECredentials(null, $scope, $idTokenAudience);

--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -18,6 +18,7 @@
 namespace Google\Auth;
 
 use DomainException;
+use InvalidArgumentException;
 use Google\Auth\Credentials\AppIdentityCredentials;
 use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\HttpHandler\HttpClientCache;

--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -105,6 +105,7 @@ class ApplicationDefaultCredentials
      * @param callable $httpHandler callback which delivers psr7 request
      * @param array $cacheConfig configuration for the cache when it's present
      * @param CacheItemPoolInterface $cache
+     * @param string $idTokenAudience The audience for the ID token.
      *
      * @return AuthTokenMiddleware
      *
@@ -115,15 +116,15 @@ class ApplicationDefaultCredentials
         callable $httpHandler = null,
         array $cacheConfig = null,
         CacheItemPoolInterface $cache = null,
-        $targetAudience = null
+        $idTokenAudience = null
 
     ) {
-        if ($scope && $targetAudience) {
+        if ($scope && $idTokenAudience) {
             throw new InvalidArgumentException(
-                'Scope and targetAudience cannot both be supplied');
+                'Scope and idTokenAudience cannot both be supplied');
         }
 
-        $creds = self::getCredentials($scope, $httpHandler, $cacheConfig, $cache, $targetAudience);
+        $creds = self::getCredentials($scope, $httpHandler, $cacheConfig, $cache, $idTokenAudience);
 
         return new AuthTokenMiddleware($creds, $httpHandler);
     }
@@ -140,6 +141,7 @@ class ApplicationDefaultCredentials
      * @param callable $httpHandler callback which delivers psr7 request
      * @param array $cacheConfig configuration for the cache when it's present
      * @param CacheItemPoolInterface $cache
+     * @param string $idTokenAudience The audience for the ID token.
      *
      * @return CredentialsLoader
      *
@@ -150,11 +152,11 @@ class ApplicationDefaultCredentials
         callable $httpHandler = null,
         array $cacheConfig = null,
         CacheItemPoolInterface $cache = null,
-        $targetAudience = null
+        $idTokenAudience = null
     ) {
-        if ($scope && $targetAudience) {
+        if ($scope && $idTokenAudience) {
             throw new InvalidArgumentException(
-                'Scope and targetAudience cannot both be supplied');
+                'Scope and idTokenAudience cannot both be supplied');
         }
 
         $creds = null;
@@ -171,11 +173,11 @@ class ApplicationDefaultCredentials
         }
 
         if (!is_null($jsonKey)) {
-            $creds = CredentialsLoader::makeCredentials($scope, $jsonKey, $targetAudience);
-        } elseif (AppIdentityCredentials::onAppEngine() && !GCECredentials::onAppEngineFlexible() && is_null($targetAudience)) {
+            $creds = CredentialsLoader::makeCredentials($scope, $jsonKey, $idTokenAudience);
+        } elseif (AppIdentityCredentials::onAppEngine() && !GCECredentials::onAppEngineFlexible() && is_null($idTokenAudience)) {
             $creds = new AppIdentityCredentials($scope);
         } elseif (GCECredentials::onGce($httpHandler)) {
-            $creds = new GCECredentials(null, $scope, $targetAudience);
+            $creds = new GCECredentials(null, $scope, $idTokenAudience);
         }
 
         if (is_null($creds)) {

--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -105,7 +105,7 @@ class ApplicationDefaultCredentials
      * @param callable $httpHandler callback which delivers psr7 request
      * @param array $cacheConfig configuration for the cache when it's present
      * @param CacheItemPoolInterface $cache
-     * @param string $idTokenAudience The audience for the ID token.
+     * @param string $targetAudience The audience for the ID token.
      *
      * @return AuthTokenMiddleware
      *
@@ -116,15 +116,15 @@ class ApplicationDefaultCredentials
         callable $httpHandler = null,
         array $cacheConfig = null,
         CacheItemPoolInterface $cache = null,
-        $idTokenAudience = null
+        $targetAudience = null
 
     ) {
-        if ($scope && $idTokenAudience) {
+        if ($scope && $targetAudience) {
             throw new InvalidArgumentException(
-                'Scope and idTokenAudience cannot both be supplied');
+                'Scope and targetAudience cannot both be supplied');
         }
 
-        $creds = self::getCredentials($scope, $httpHandler, $cacheConfig, $cache, $idTokenAudience);
+        $creds = self::getCredentials($scope, $httpHandler, $cacheConfig, $cache, $targetAudience);
 
         return new AuthTokenMiddleware($creds, $httpHandler);
     }
@@ -141,7 +141,7 @@ class ApplicationDefaultCredentials
      * @param callable $httpHandler callback which delivers psr7 request
      * @param array $cacheConfig configuration for the cache when it's present
      * @param CacheItemPoolInterface $cache
-     * @param string $idTokenAudience The audience for the ID token.
+     * @param string $targetAudience The audience for the ID token.
      *
      * @return CredentialsLoader
      *
@@ -152,11 +152,11 @@ class ApplicationDefaultCredentials
         callable $httpHandler = null,
         array $cacheConfig = null,
         CacheItemPoolInterface $cache = null,
-        $idTokenAudience = null
+        $targetAudience = null
     ) {
-        if ($scope && $idTokenAudience) {
+        if ($scope && $targetAudience) {
             throw new InvalidArgumentException(
-                'Scope and idTokenAudience cannot both be supplied');
+                'Scope and targetAudience cannot both be supplied');
         }
 
         $creds = null;
@@ -173,15 +173,15 @@ class ApplicationDefaultCredentials
         }
 
         if (!is_null($jsonKey)) {
-            $creds = CredentialsLoader::makeCredentials($scope, $jsonKey, $idTokenAudience);
+            $creds = CredentialsLoader::makeCredentials($scope, $jsonKey, $targetAudience);
         } elseif (AppIdentityCredentials::onAppEngine() && !GCECredentials::onAppEngineFlexible()) {
-            if (!empty($idTokenAudience)) {
+            if (!empty($targetAudience)) {
                 throw new \InvalidArgumentException(
-                    'idTokenAudience is not valid on older versions of App Engine');
+                    'targetAudience is not valid on older versions of App Engine');
             }
             $creds = new AppIdentityCredentials($scope);
         } elseif (GCECredentials::onGce($httpHandler)) {
-            $creds = new GCECredentials(null, $scope, $idTokenAudience);
+            $creds = new GCECredentials(null, $scope, $targetAudience);
         }
 
         if (is_null($creds)) {

--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -207,7 +207,8 @@ class ApplicationDefaultCredentials
 
     /**
      * Obtains the default FetchAuthTokenInterface implementation to use
-     * in this environment.
+     * in this environment, configured with a $targetAudience for fetching an ID
+     * token.
      *
      * @param string $targetAudience The audience for the ID token.
      * @param callable $httpHandler callback which delivers psr7 request

--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -167,7 +167,7 @@ class ApplicationDefaultCredentials
         }
 
         if (is_null($creds)) {
-            throw new \DomainException(self::notFound());
+            throw new DomainException(self::notFound());
         }
         if (!is_null($cache)) {
             $creds = new FetchAuthTokenCache($creds, $cacheConfig, $cache);
@@ -215,6 +215,7 @@ class ApplicationDefaultCredentials
      * @return CredentialsLoader
      *
      * @throws DomainException if no implementation can be obtained.
+     * @throws InvalidArgumentException if JSON "type" key is invalid
      */
     public static function getIdTokenCredentials(
         $targetAudience,
@@ -244,16 +245,10 @@ class ApplicationDefaultCredentials
             $creds = new ServiceAccountCredentials(null, $jsonKey, null, $targetAudience);
         } elseif (GCECredentials::onGce($httpHandler)) {
             $creds = new GCECredentials(null, null, $targetAudience);
-        } elseif (
-            AppIdentityCredentials::onAppEngine()
-            && !GCECredentials::onAppEngineFlexible()
-        ) {
-            throw new InvalidArgumentException(
-                'targetAudience is not valid on older versions of App Engine');
         }
 
         if (is_null($creds)) {
-            throw new \DomainException(self::notFound());
+            throw new DomainException(self::notFound());
         }
         if (!is_null($cache)) {
             $creds = new FetchAuthTokenCache($creds, $cacheConfig, $cache);

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -163,9 +163,7 @@ class GCECredentials extends CredentialsLoader implements SignBlobInterface
             $tokenUri = $tokenUri . '?scopes='. $scope;
         } elseif ($targetAudience) {
             $tokenUri = self::getIdTokenUri();
-            if ($targetAudience) {
-                $tokenUri . '?audience=' . $targetAudience;
-            }
+            $tokenUri .= '?audience=' . $targetAudience;
             $tokenType = self::TOKEN_TYPE_ID_TOKEN;
         }
 

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -139,16 +139,15 @@ class GCECredentials extends CredentialsLoader implements SignBlobInterface
      * @param Iam $iam [optional] An IAM instance.
      * @param string|array $scope [optional] the scope of the access request,
      *        expressed either as an array or as a space-delimited string.
-     * @param string $targetAudience [optional] the target audience for
-     *        the ID token.
+     * @param string $idTokenAudience [optional] The audience for the ID token.
      */
-    public function __construct(Iam $iam = null, $scope = null, $targetAudience = null)
+    public function __construct(Iam $iam = null, $scope = null, $idTokenAudience = null)
     {
         $this->iam = $iam;
 
-        if ($scope && $targetAudience) {
+        if ($scope && $idTokenAudience) {
             throw new InvalidArgumentException(
-                'Scope and targetAudience cannot both be supplied');
+                'Scope and idTokenAudience cannot both be supplied');
         }
 
         $tokenType = self::TOKEN_TYPE_ACCESS_TOKEN;
@@ -161,9 +160,9 @@ class GCECredentials extends CredentialsLoader implements SignBlobInterface
             $scope = implode(',', $scope);
 
             $tokenUri = $tokenUri . '?scopes='. $scope;
-        } elseif ($targetAudience) {
+        } elseif ($idTokenAudience) {
             $tokenUri = self::getIdTokenUri();
-            $tokenUri .= '?audience=' . $targetAudience;
+            $tokenUri .= '?audience=' . $idTokenAudience;
             $tokenType = self::TOKEN_TYPE_ID_TOKEN;
         }
 

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -139,15 +139,15 @@ class GCECredentials extends CredentialsLoader implements SignBlobInterface
      * @param Iam $iam [optional] An IAM instance.
      * @param string|array $scope [optional] the scope of the access request,
      *        expressed either as an array or as a space-delimited string.
-     * @param string $idTokenAudience [optional] The audience for the ID token.
+     * @param string $targetAudience [optional] The audience for the ID token.
      */
-    public function __construct(Iam $iam = null, $scope = null, $idTokenAudience = null)
+    public function __construct(Iam $iam = null, $scope = null, $targetAudience = null)
     {
         $this->iam = $iam;
 
-        if ($scope && $idTokenAudience) {
+        if ($scope && $targetAudience) {
             throw new InvalidArgumentException(
-                'Scope and idTokenAudience cannot both be supplied');
+                'Scope and targetAudience cannot both be supplied');
         }
 
         $tokenType = self::TOKEN_TYPE_ACCESS_TOKEN;
@@ -160,9 +160,9 @@ class GCECredentials extends CredentialsLoader implements SignBlobInterface
             $scope = implode(',', $scope);
 
             $tokenUri = $tokenUri . '?scopes='. $scope;
-        } elseif ($idTokenAudience) {
+        } elseif ($targetAudience) {
             $tokenUri = self::getIdTokenUri();
-            $tokenUri .= '?audience=' . $idTokenAudience;
+            $tokenUri .= '?audience=' . $targetAudience;
             $tokenType = self::TOKEN_TYPE_ID_TOKEN;
         }
 

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -187,7 +187,7 @@ class GCECredentials extends CredentialsLoader implements SignBlobInterface
      *
      * @return string
      */
-    public static function getIdTokenUri()
+    private static function getIdTokenUri()
     {
         $base = 'http://' . self::METADATA_IP . '/computeMetadata/';
 

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -26,6 +26,7 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
+use InvalidArgumentException;
 
 /**
  * GCECredentials supports authorization on Google Compute Engine.

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -75,14 +75,13 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
      *   as an associative array
      * @param string $sub an email address account to impersonate, in situations when
      *   the service account has been delegated domain wide access.
-     * @param string $targetAudience [optional] the target audience for
-     *        the ID token.
+     * @param string $idTokenAudience The audience for the ID token.
      */
     public function __construct(
         $scope,
         $jsonKey,
         $sub = null,
-        $targetAudience = null
+        $idTokenAudience = null
     ) {
         if (is_string($jsonKey)) {
             if (!file_exists($jsonKey)) {
@@ -102,8 +101,8 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
                 'json key is missing the private_key field');
         }
         $additionalClaims = [];
-        if ($targetAudience) {
-            $additionalClaims = ['target_audience' => $targetAudience];
+        if ($idTokenAudience) {
+            $additionalClaims = ['target_audience' => $idTokenAudience];
         }
         $this->auth = new OAuth2([
             'audience' => self::TOKEN_CREDENTIAL_URI,

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -75,11 +75,14 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
      *   as an associative array
      * @param string $sub an email address account to impersonate, in situations when
      *   the service account has been delegated domain wide access.
+     * @param string $targetAudience [optional] the target audience for
+     *        the ID token.
      */
     public function __construct(
         $scope,
         $jsonKey,
-        $sub = null
+        $sub = null,
+        $targetAudience = null
     ) {
         if (is_string($jsonKey)) {
             if (!file_exists($jsonKey)) {
@@ -98,6 +101,10 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
             throw new \InvalidArgumentException(
                 'json key is missing the private_key field');
         }
+        $additionalClaims = [];
+        if ($targetAudience) {
+            $additionalClaims = ['target_audience' => $targetAudience];
+        }
         $this->auth = new OAuth2([
             'audience' => self::TOKEN_CREDENTIAL_URI,
             'issuer' => $jsonKey['client_email'],
@@ -106,6 +113,7 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
             'signingKey' => $jsonKey['private_key'],
             'sub' => $sub,
             'tokenCredentialUri' => self::TOKEN_CREDENTIAL_URI,
+            'additionalClaims' => $additionalClaims,
         ]);
     }
 

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -75,13 +75,13 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
      *   as an associative array
      * @param string $sub an email address account to impersonate, in situations when
      *   the service account has been delegated domain wide access.
-     * @param string $idTokenAudience The audience for the ID token.
+     * @param string $targetAudience The audience for the ID token.
      */
     public function __construct(
         $scope,
         $jsonKey,
         $sub = null,
-        $idTokenAudience = null
+        $targetAudience = null
     ) {
         if (is_string($jsonKey)) {
             if (!file_exists($jsonKey)) {
@@ -101,8 +101,8 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
                 'json key is missing the private_key field');
         }
         $additionalClaims = [];
-        if ($idTokenAudience) {
-            $additionalClaims = ['target_audience' => $idTokenAudience];
+        if ($targetAudience) {
+            $additionalClaims = ['target_audience' => $targetAudience];
         }
         $this->auth = new OAuth2([
             'audience' => self::TOKEN_CREDENTIAL_URI,

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -21,6 +21,7 @@ use Google\Auth\CredentialsLoader;
 use Google\Auth\OAuth2;
 use Google\Auth\ServiceAccountSignerTrait;
 use Google\Auth\SignBlobInterface;
+use InvalidArgumentException;
 
 /**
  * ServiceAccountCredentials supports authorization using a Google service
@@ -99,6 +100,10 @@ class ServiceAccountCredentials extends CredentialsLoader implements SignBlobInt
         if (!array_key_exists('private_key', $jsonKey)) {
             throw new \InvalidArgumentException(
                 'json key is missing the private_key field');
+        }
+        if ($scope && $targetAudience) {
+            throw new InvalidArgumentException(
+                'Scope and targetAudience cannot both be supplied');
         }
         $additionalClaims = [];
         if ($targetAudience) {

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -32,6 +32,9 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
     const WELL_KNOWN_PATH = 'gcloud/application_default_credentials.json';
     const NON_WINDOWS_WELL_KNOWN_PATH_BASE = '.config';
     const AUTH_METADATA_KEY = 'authorization';
+    const TOKEN_TYPE_ACCESS_TOKEN = 1;
+    const TOKEN_TYPE_ID_TOKEN = 2;
+
 
     /**
      * @param string $cause
@@ -110,17 +113,18 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
      * @param string|array $scope the scope of the access request, expressed
      *   either as an Array or as a space-delimited String.
      * @param array $jsonKey the JSON credentials.
+     * @param $targetAudience The target audience for the ID token.
      *
      * @return ServiceAccountCredentials|UserRefreshCredentials
      */
-    public static function makeCredentials($scope, array $jsonKey)
+    public static function makeCredentials($scope, array $jsonKey, $targetAudience = null)
     {
         if (!array_key_exists('type', $jsonKey)) {
             throw new \InvalidArgumentException('json key is missing the type field');
         }
 
         if ($jsonKey['type'] == 'service_account') {
-            return new ServiceAccountCredentials($scope, $jsonKey);
+            return new ServiceAccountCredentials($scope, $jsonKey, $targetAudience);
         }
 
         if ($jsonKey['type'] == 'authorized_user') {

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -124,7 +124,7 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
         }
 
         if ($jsonKey['type'] == 'service_account') {
-            return new ServiceAccountCredentials($scope, $jsonKey, $targetAudience);
+            return new ServiceAccountCredentials($scope, $jsonKey, null, $targetAudience);
         }
 
         if ($jsonKey['type'] == 'authorized_user') {

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -113,18 +113,18 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
      * @param string|array $scope the scope of the access request, expressed
      *   either as an Array or as a space-delimited String.
      * @param array $jsonKey the JSON credentials.
-     * @param $targetAudience The target audience for the ID token.
+     * @param string $idTokenAudience The audience for the ID token.
      *
      * @return ServiceAccountCredentials|UserRefreshCredentials
      */
-    public static function makeCredentials($scope, array $jsonKey, $targetAudience = null)
+    public static function makeCredentials($scope, array $jsonKey, $idTokenAudience = null)
     {
         if (!array_key_exists('type', $jsonKey)) {
             throw new \InvalidArgumentException('json key is missing the type field');
         }
 
         if ($jsonKey['type'] == 'service_account') {
-            return new ServiceAccountCredentials($scope, $jsonKey, null, $targetAudience);
+            return new ServiceAccountCredentials($scope, $jsonKey, null, $idTokenAudience);
         }
 
         if ($jsonKey['type'] == 'authorized_user') {

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -35,7 +35,6 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
     const TOKEN_TYPE_ACCESS_TOKEN = 1;
     const TOKEN_TYPE_ID_TOKEN = 2;
 
-
     /**
      * @param string $cause
      * @return string
@@ -113,18 +112,17 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
      * @param string|array $scope the scope of the access request, expressed
      *   either as an Array or as a space-delimited String.
      * @param array $jsonKey the JSON credentials.
-     * @param string $targetAudience The audience for the ID token.
      *
      * @return ServiceAccountCredentials|UserRefreshCredentials
      */
-    public static function makeCredentials($scope, array $jsonKey, $targetAudience = null)
+    public static function makeCredentials($scope, array $jsonKey)
     {
         if (!array_key_exists('type', $jsonKey)) {
             throw new \InvalidArgumentException('json key is missing the type field');
         }
 
         if ($jsonKey['type'] == 'service_account') {
-            return new ServiceAccountCredentials($scope, $jsonKey, null, $targetAudience);
+            return new ServiceAccountCredentials($scope, $jsonKey);
         }
 
         if ($jsonKey['type'] == 'authorized_user') {

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -32,8 +32,6 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
     const WELL_KNOWN_PATH = 'gcloud/application_default_credentials.json';
     const NON_WINDOWS_WELL_KNOWN_PATH_BASE = '.config';
     const AUTH_METADATA_KEY = 'authorization';
-    const TOKEN_TYPE_ACCESS_TOKEN = 1;
-    const TOKEN_TYPE_ID_TOKEN = 2;
 
     /**
      * @param string $cause

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -113,18 +113,18 @@ abstract class CredentialsLoader implements FetchAuthTokenInterface
      * @param string|array $scope the scope of the access request, expressed
      *   either as an Array or as a space-delimited String.
      * @param array $jsonKey the JSON credentials.
-     * @param string $idTokenAudience The audience for the ID token.
+     * @param string $targetAudience The audience for the ID token.
      *
      * @return ServiceAccountCredentials|UserRefreshCredentials
      */
-    public static function makeCredentials($scope, array $jsonKey, $idTokenAudience = null)
+    public static function makeCredentials($scope, array $jsonKey, $targetAudience = null)
     {
         if (!array_key_exists('type', $jsonKey)) {
             throw new \InvalidArgumentException('json key is missing the type field');
         }
 
         if ($jsonKey['type'] == 'service_account') {
-            return new ServiceAccountCredentials($scope, $jsonKey, null, $idTokenAudience);
+            return new ServiceAccountCredentials($scope, $jsonKey, null, $targetAudience);
         }
 
         if ($jsonKey['type'] == 'authorized_user') {

--- a/src/Middleware/AuthTokenMiddleware.php
+++ b/src/Middleware/AuthTokenMiddleware.php
@@ -122,5 +122,9 @@ class AuthTokenMiddleware
 
             return $auth_tokens['access_token'];
         }
+
+        if (array_key_exists('id_token', $auth_tokens)) {
+            return $auth_tokens['id_token'];
+        }
     }
 }

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -377,12 +377,21 @@ class ADCGetCredentialsAppEngineTest extends BaseTest
     public function testAppEngineStandardIdToken()
     {
         $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
-        ApplicationDefaultCredentials::getCredentials(
+        $httpHandler = getHandler([
+            buildResponse(503),
+            buildResponse(503),
+            buildResponse(503),
+        ]);
+        $credentials = ApplicationDefaultCredentials::getCredentials(
             null,
-            null,
+            $httpHandler,
             null,
             null,
             'a target audience'
+        );
+        $this->assertNotInstanceOf(
+            'Google\Auth\Credentials\AppIdentityCredentials',
+            $credentials
         );
     }
 

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -43,14 +43,14 @@ class ADCGetTest extends TestCase
     /**
      * @expectedException InvalidArgumentException
      */
-    public function testFailsIfBothScopeAndTargetAudienceAreSupplied()
+    public function testFailsIfBothScopeAndIdTokenAudienceAreSupplied()
     {
         ApplicationDefaultCredentials::getCredentials(
             'a scope',
             null,
             null,
             null,
-            'a target audience'
+            'an id token audience'
         );
     }
 
@@ -214,7 +214,7 @@ class ADCGetMiddlewareTest extends TestCase
     }
 }
 
-class ADCGetCredentialsWithTargetAudienceTest extends TestCase
+class ADCGetCredentialsWithIdTokenAudienceTest extends TestCase
 {
     private $originalHome;
 
@@ -238,20 +238,20 @@ class ADCGetCredentialsWithTargetAudienceTest extends TestCase
     {
         $keyFile = __DIR__ . '/fixtures' . '/does-not-exist-private.json';
         putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
-        ApplicationDefaultCredentials::getCredentials(null, null, null, null, 'a target audience');
+        ApplicationDefaultCredentials::getCredentials(null, null, null, null, 'an id token audience');
     }
 
     public function testLoadsOKIfEnvSpecifiedIsValid()
     {
         $keyFile = __DIR__ . '/fixtures' . '/private.json';
         putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
-        ApplicationDefaultCredentials::getCredentials(null, null, null, null, 'a target audience');
+        ApplicationDefaultCredentials::getCredentials(null, null, null, null, 'an id token audience');
     }
 
     public function testLoadsDefaultFileIfPresentAndEnvVarIsNotSet()
     {
         putenv('HOME=' . __DIR__ . '/fixtures');
-        ApplicationDefaultCredentials::getCredentials(null, null, null, null, 'a target audience');
+        ApplicationDefaultCredentials::getCredentials(null, null, null, null, 'an id token audience');
     }
 
     /**
@@ -268,7 +268,7 @@ class ADCGetCredentialsWithTargetAudienceTest extends TestCase
             buildResponse(500)
         ]);
 
-        ApplicationDefaultCredentials::getCredentials(null, $httpHandler, null, null, 'a target audience');
+        ApplicationDefaultCredentials::getCredentials(null, $httpHandler, null, null, 'an id token audience');
     }
 
     public function testWithCacheOptions()
@@ -288,7 +288,7 @@ class ADCGetCredentialsWithTargetAudienceTest extends TestCase
             $httpHandler,
             $cacheOptions,
             $cachePool->reveal(),
-            'a target audience'
+            'an id token audience'
         );
 
         $this->assertInstanceOf('Google\Auth\FetchAuthTokenCache', $credentials);
@@ -315,7 +315,7 @@ class ADCGetCredentialsWithTargetAudienceTest extends TestCase
             $httpHandler,
             null,
             null,
-            'a target audience'
+            'an id token audience'
         );
 
         $this->assertInstanceOf(
@@ -387,7 +387,7 @@ class ADCGetCredentialsAppEngineTest extends BaseTest
             $httpHandler,
             null,
             null,
-            'a target audience'
+            'an id token audience'
         );
         $this->assertNotInstanceOf(
             'Google\Auth\Credentials\AppIdentityCredentials',
@@ -407,7 +407,7 @@ class ADCGetCredentialsAppEngineTest extends BaseTest
             $httpHandler,
             null,
             null,
-            'a target audience'
+            'an id token audience'
         );
         $this->assertInstanceOf(
             'Google\Auth\Credentials\GCECredentials',

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -372,7 +372,8 @@ class ADCGetCredentialsAppEngineTest extends BaseTest
     }
 
     /**
-     * @expectedException DomainException
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage idTokenAudience is not valid on older versions of App Engine
      */
     public function testAppEngineStandardIdToken()
     {

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -373,7 +373,7 @@ class ADCGetCredentialsAppEngineTest extends BaseTest
 
     /**
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage idTokenAudience is not valid on older versions of App Engine
+     * @expectedExceptionMessage targetAudience is not valid on older versions of App Engine
      */
     public function testAppEngineStandardIdToken()
     {

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -247,7 +247,6 @@ class ADCGetCredentialsWithIdTokenAudienceTest extends TestCase
     public function testFailsIfNotOnGceAndNoDefaultFileFound()
     {
         putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
-        putenv('SERVER_SOFTWARE');
 
         // simulate not being GCE and retry attempts by returning multiple 500s
         $httpHandler = getHandler([
@@ -256,7 +255,6 @@ class ADCGetCredentialsWithIdTokenAudienceTest extends TestCase
             buildResponse(500)
         ]);
 
-        $_SERVER['SERVER_SOFTWARE'] = '';
         ApplicationDefaultCredentials::getIdTokenCredentials(
             $this->targetAudience,
             $httpHandler
@@ -357,28 +355,6 @@ class ADCGetCredentialsAppEngineTest extends BaseTest
         $this->assertInstanceOf(
             'Google\Auth\Credentials\GCECredentials',
             ApplicationDefaultCredentials::getCredentials(null, $httpHandler)
-        );
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage targetAudience is not valid on older versions of App Engine
-     */
-    public function testAppEngineStandardIdToken()
-    {
-        $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
-        $httpHandler = getHandler([
-            buildResponse(503),
-            buildResponse(503),
-            buildResponse(503),
-        ]);
-        $credentials = ApplicationDefaultCredentials::getIdTokenCredentials(
-            $this->targetAudience,
-            $httpHandler
-        );
-        $this->assertNotInstanceOf(
-            'Google\Auth\Credentials\AppIdentityCredentials',
-            $credentials
         );
     }
 

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -200,10 +200,10 @@ class ADCGetMiddlewareTest extends TestCase
     }
 }
 
-class ADCGetCredentialsWithIdTokenAudienceTest extends TestCase
+class ADCGetCredentialsWithTargetAudienceTest extends TestCase
 {
     private $originalHome;
-    private $targetAudience = 'an id token audience';
+    private $targetAudience = 'a target audience';
 
     protected function setUp()
     {
@@ -315,7 +315,7 @@ class ADCGetCredentialsAppEngineTest extends BaseTest
 {
     private $originalHome;
     private $originalServiceAccount;
-    private $targetAudience = 'an id token audience';
+    private $targetAudience = 'a target audience';
 
     protected function setUp()
     {

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -215,7 +215,7 @@ class ADCGetCredentialsWithTargetAudienceTest extends TestCase
         if ($this->originalHome != getenv('HOME')) {
             putenv('HOME=' . $this->originalHome);
         }
-        putenv(ServiceAccountCredentials::ENV_VAR);  // removes it from
+        putenv(ServiceAccountCredentials::ENV_VAR);  // removes environment variable
     }
 
     /**

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -151,7 +151,7 @@ class GCECredentialsTest extends TestCase
         $httpHandler = function ($request) use (&$timesCalled, $expectedToken) {
             $timesCalled++;
             if ($timesCalled == 1) {
-                return buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']);
+                return new Psr7\Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']);
             }
             $this->assertEquals(
                 '/computeMetadata/' . GCECredentials::ID_TOKEN_URI_PATH,
@@ -161,7 +161,7 @@ class GCECredentialsTest extends TestCase
                 'audience=a+target+audience',
                 $request->getUri()->getQuery()
             );
-            return buildResponse(200, [], Psr7\stream_for($expectedToken['id_token']));
+            return new Psr7\Response(200, [], Psr7\stream_for($expectedToken['id_token']));
 
         };
         $g = new GCECredentials(null, null, 'a+target+audience');

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -144,7 +144,7 @@ class GCECredentialsTest extends TestCase
         $this->assertEquals(time() + 57, $g->getLastReceivedToken()['expires_at']);
     }
 
-    public function testFetchAuthTokenShouldBeIdTokenWhenTargetAudienceIsSet()
+    public function testFetchAuthTokenShouldBeIdTokenWhenIdTokenAudienceIsSet()
     {
         $expectedToken = ['id_token' => 'idtoken12345'];
         $timesCalled = 0;
@@ -158,13 +158,13 @@ class GCECredentialsTest extends TestCase
                 $request->getUri()->getPath()
             );
             $this->assertEquals(
-                'audience=a+target+audience',
+                'audience=an+id+token+audience',
                 $request->getUri()->getQuery()
             );
             return new Psr7\Response(200, [], Psr7\stream_for($expectedToken['id_token']));
 
         };
-        $g = new GCECredentials(null, null, 'a+target+audience');
+        $g = new GCECredentials(null, null, 'an+id+token+audience');
         $this->assertEquals($expectedToken, $g->fetchAuthToken($httpHandler));
         $this->assertEquals(2, $timesCalled);
     }

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -144,7 +144,7 @@ class GCECredentialsTest extends TestCase
         $this->assertEquals(time() + 57, $g->getLastReceivedToken()['expires_at']);
     }
 
-    public function testFetchAuthTokenShouldBeIdTokenWhenIdTokenAudienceIsSet()
+    public function testFetchAuthTokenShouldBeIdTokenWhenTargetAudienceIsSet()
     {
         $expectedToken = ['id_token' => 'idtoken12345'];
         $timesCalled = 0;
@@ -158,15 +158,24 @@ class GCECredentialsTest extends TestCase
                 $request->getUri()->getPath()
             );
             $this->assertEquals(
-                'audience=an+id+token+audience',
+                'audience=a+target+audience',
                 $request->getUri()->getQuery()
             );
             return new Psr7\Response(200, [], Psr7\stream_for($expectedToken['id_token']));
 
         };
-        $g = new GCECredentials(null, null, 'an+id+token+audience');
+        $g = new GCECredentials(null, null, 'a+target+audience');
         $this->assertEquals($expectedToken, $g->fetchAuthToken($httpHandler));
         $this->assertEquals(2, $timesCalled);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Scope and targetAudience cannot both be supplied
+     */
+    public function testSettingBothScopeAndTargetAudienceThrowsException()
+    {
+        $g = new GCECredentials(null, 'a-scope', 'a+target+audience');
     }
 
     /**

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -144,6 +144,31 @@ class GCECredentialsTest extends TestCase
         $this->assertEquals(time() + 57, $g->getLastReceivedToken()['expires_at']);
     }
 
+    public function testFetchAuthTokenShouldBeIdTokenWhenTargetAudienceIsSet()
+    {
+        $expectedToken = ['id_token' => 'idtoken12345'];
+        $timesCalled = 0;
+        $httpHandler = function ($request) use (&$timesCalled, $expectedToken) {
+            $timesCalled++;
+            if ($timesCalled == 1) {
+                return buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']);
+            }
+            $this->assertEquals(
+                '/computeMetadata/' . GCECredentials::ID_TOKEN_URI_PATH,
+                $request->getUri()->getPath()
+            );
+            $this->assertEquals(
+                'audience=a+target+audience',
+                $request->getUri()->getQuery()
+            );
+            return buildResponse(200, [], Psr7\stream_for($expectedToken['id_token']));
+
+        };
+        $g = new GCECredentials(null, null, 'a+target+audience');
+        $this->assertEquals($expectedToken, $g->fetchAuthToken($httpHandler));
+        $this->assertEquals(2, $timesCalled);
+    }
+
     /**
      * @dataProvider scopes
      */

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -341,7 +341,7 @@ class SACFetchAuthTokenTest extends TestCase
             $this->assertArrayHasKey('target_audience', $jwtParams);
             $this->assertEquals('a target audience', $jwtParams['target_audience']);
 
-            return buildResponse(200, [], Psr7\stream_for(json_encode($expectedToken)));
+            return new Psr7\Response(200, [], Psr7\stream_for(json_encode($expectedToken)));
 
         };
         $sa = new ServiceAccountCredentials(null, $testJson, null, 'a target audience');

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -327,7 +327,7 @@ class SACFetchAuthTokenTest extends TestCase
             array('Bearer ' . $access_token));
     }
 
-    public function testShouldBeIdTokenWhenTargetAudienceIsSet()
+    public function testShouldBeIdTokenWhenIdTokenAudienceIsSet()
     {
         $testJson = $this->createTestJson();
         $expectedToken = ['id_token' => 'idtoken12345'];
@@ -339,12 +339,12 @@ class SACFetchAuthTokenTest extends TestCase
             list($header, $payload, $sig) = explode('.', $post['assertion']);
             $jwtParams = json_decode(base64_decode($payload), true);
             $this->assertArrayHasKey('target_audience', $jwtParams);
-            $this->assertEquals('a target audience', $jwtParams['target_audience']);
+            $this->assertEquals('an id token audience', $jwtParams['target_audience']);
 
             return new Psr7\Response(200, [], Psr7\stream_for(json_encode($expectedToken)));
 
         };
-        $sa = new ServiceAccountCredentials(null, $testJson, null, 'a target audience');
+        $sa = new ServiceAccountCredentials(null, $testJson, null, 'an id token audience');
         $this->assertEquals($expectedToken, $sa->fetchAuthToken($httpHandler));
         $this->assertEquals(1, $timesCalled);
     }

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -327,7 +327,7 @@ class SACFetchAuthTokenTest extends TestCase
             array('Bearer ' . $access_token));
     }
 
-    public function testShouldBeIdTokenWhenIdTokenAudienceIsSet()
+    public function testShouldBeIdTokenWhenTargetAudienceIsSet()
     {
         $testJson = $this->createTestJson();
         $expectedToken = ['id_token' => 'idtoken12345'];
@@ -339,14 +339,29 @@ class SACFetchAuthTokenTest extends TestCase
             list($header, $payload, $sig) = explode('.', $post['assertion']);
             $jwtParams = json_decode(base64_decode($payload), true);
             $this->assertArrayHasKey('target_audience', $jwtParams);
-            $this->assertEquals('an id token audience', $jwtParams['target_audience']);
+            $this->assertEquals('a target audience', $jwtParams['target_audience']);
 
             return new Psr7\Response(200, [], Psr7\stream_for(json_encode($expectedToken)));
 
         };
-        $sa = new ServiceAccountCredentials(null, $testJson, null, 'an id token audience');
+        $sa = new ServiceAccountCredentials(null, $testJson, null, 'a target audience');
         $this->assertEquals($expectedToken, $sa->fetchAuthToken($httpHandler));
         $this->assertEquals(1, $timesCalled);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Scope and targetAudience cannot both be supplied
+     */
+    public function testSettingBothScopeAndTargetAudienceThrowsException()
+    {
+        $testJson = $this->createTestJson();
+        $sa = new ServiceAccountCredentials(
+            'a-scope',
+            $testJson,
+            null,
+            'a-target-audience'
+        );
     }
 }
 

--- a/tests/Middleware/AuthTokenMiddlewareTest.php
+++ b/tests/Middleware/AuthTokenMiddlewareTest.php
@@ -284,7 +284,6 @@ class AuthTokenMiddlewareTest extends BaseTest
             [new MiddlewareCallback],
         ];
     }
-
 }
 
 class MiddlewareCallback

--- a/tests/Middleware/AuthTokenMiddlewareTest.php
+++ b/tests/Middleware/AuthTokenMiddlewareTest.php
@@ -86,6 +86,26 @@ class AuthTokenMiddlewareTest extends BaseTest
         $callable($this->mockRequest->reveal(), ['auth' => 'google_auth']);
     }
 
+    public function testUsesIdTokenWhenAccessTokenDoesNotExist()
+    {
+        $token = 'idtoken12345';
+        $authResult = ['id_token' => $token];
+        $this->mockFetcher
+            ->expects($this->once())
+            ->method('fetchAuthToken')
+            ->will($this->returnValue($authResult));
+        $this->mockRequest
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('authorization', 'Bearer ' . $token)
+            ->will($this->returnValue($this->mockRequest));
+
+        $middleware = new AuthTokenMiddleware($this->mockFetcher);
+        $mock = new MockHandler([new Response(200)]);
+        $callable = $middleware($mock);
+        $callable($this->mockRequest, ['auth' => 'google_auth']);
+    }
+
     public function testUsesCachedAuthToken()
     {
         $cacheKey = 'myKey';
@@ -264,6 +284,7 @@ class AuthTokenMiddlewareTest extends BaseTest
             [new MiddlewareCallback],
         ];
     }
+
 }
 
 class MiddlewareCallback

--- a/tests/Middleware/AuthTokenMiddlewareTest.php
+++ b/tests/Middleware/AuthTokenMiddlewareTest.php
@@ -90,20 +90,15 @@ class AuthTokenMiddlewareTest extends BaseTest
     {
         $token = 'idtoken12345';
         $authResult = ['id_token' => $token];
-        $this->mockFetcher
-            ->expects($this->once())
-            ->method('fetchAuthToken')
-            ->will($this->returnValue($authResult));
-        $this->mockRequest
-            ->expects($this->once())
-            ->method('withHeader')
-            ->with('authorization', 'Bearer ' . $token)
-            ->will($this->returnValue($this->mockRequest));
+        $this->mockFetcher->fetchAuthToken(Argument::any())
+            ->willReturn($authResult);
+        $this->mockRequest->withHeader('authorization', 'Bearer ' . $token)
+            ->willReturn($this->mockRequest);
 
-        $middleware = new AuthTokenMiddleware($this->mockFetcher);
+        $middleware = new AuthTokenMiddleware($this->mockFetcher->reveal());
         $mock = new MockHandler([new Response(200)]);
         $callable = $middleware($mock);
-        $callable($this->mockRequest, ['auth' => 'google_auth']);
+        $callable($this->mockRequest->reveal(), ['auth' => 'google_auth']);
     }
 
     public function testUsesCachedAuthToken()


### PR DESCRIPTION
This uses existing `Auth Token` methods to also return ID tokens

Adding a fifth parameter is not ideal, but there isn't really a better way to do it without either

 1. Refactoring several methods to take an options array as the first parameter
 2. Breaking B.C. and bumping this library a major version