### PR TITLE
chore: update changelog for 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.1 (10/29/2019)
+
+* [fix] Handle DST correctly for cache item expirations. (#246)
+
 ## 1.6.0 (10/01/2019)
 
 * [feat] Add utility for verifying and revoking access tokens. (#243)


### PR DESCRIPTION
## 1.6.1 (10/29/2019)

* [fix] Handle DST correctly for cache item expirations. (#246)