### PR TITLE
feat: Adds support for ES256 in AccessToken::verify

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "friendsofphp/php-cs-fixer": "^1.11",
     "phpunit/phpunit": "^4.8.36|^5.7",
     "sebastian/comparator": ">=1.2.3",
-    "phpseclib/phpseclib": "^2"
+    "phpseclib/phpseclib": "^2",
+    "kelvinmo/simplejwt": "^0.2.5"
   },
   "suggest": {
     "phpseclib/phpseclib": "May be used in place of OpenSSL for signing strings or for token management. Please require version ^2."

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -429,7 +429,6 @@ class AccessToken
     /**
      * Provide a hook to mock calls to the JWT static methods.
      *
-     * @param string $method
      * @param array $args
      * @return mixed
      */

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -343,7 +343,7 @@ class AccessToken
     private function checkAndInitializePhpsec()
     {
         // @codeCoverageIgnoreStart
-        if (!class_exists(RSA::class)) {
+        if (!class_exists('phpseclib\Crypt\RSA')) {
             throw new \RuntimeException('Please require phpseclib/phpseclib v2 to use this utility.');
         }
         // @codeCoverageIgnoreEnd
@@ -354,7 +354,7 @@ class AccessToken
     private function checkSimpleJwt()
     {
         // @codeCoverageIgnoreStart
-        if (!class_exists(SimpleJWT::class)) {
+        if (!class_exists('SimpleJWT\JWT')) {
             throw new \RuntimeException('Please require kelvinmo/simplejwtlib ^0.2 to use this utility.');
         }
         // @codeCoverageIgnoreEnd
@@ -405,7 +405,7 @@ class AccessToken
      */
     protected function callSimpleJwtDecode(array $args = [])
     {
-        return call_user_func_array([SimpleJWT::class, 'decode'], $args);
+        return call_user_func_array(['SimpleJWT\JWT', 'decode'], $args);
     }
 
     /**

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -27,6 +27,10 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use phpseclib\Crypt\RSA;
 use phpseclib\Math\BigInteger;
+use SimpleJWT\JWT as SimpleJWT;
+use SimpleJWT\Keys\KeyFactory;
+use SimpleJWT\Keys\KeySet;
+use SimpleJWT\InvalidTokenException;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -37,6 +41,7 @@ use Psr\Cache\CacheItemPoolInterface;
 class AccessToken
 {
     const FEDERATED_SIGNON_CERT_URL = 'https://www.googleapis.com/oauth2/v3/certs';
+    const IAP_CERT_URL = 'https://www.gstatic.com/iap/verify/public_key-jwk';
     const OAUTH2_ISSUER = 'accounts.google.com';
     const OAUTH2_ISSUER_HTTPS = 'https://accounts.google.com';
     const OAUTH2_REVOKE_URI = 'https://oauth2.googleapis.com/revoke';
@@ -59,19 +64,9 @@ class AccessToken
         callable $httpHandler = null,
         CacheItemPoolInterface $cache = null
     ) {
-        // @codeCoverageIgnoreStart
-        if (!class_exists('phpseclib\Crypt\RSA')) {
-            throw new \RuntimeException('Please require phpseclib/phpseclib v2 to use this utility.');
-        }
-        // @codeCoverageIgnoreEnd
-
         $this->httpHandler = $httpHandler
             ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());
         $this->cache = $cache ?: new MemoryCacheItemPool();
-        $this->configureJwtService();
-
-        // set phpseclib constants if applicable
-        $this->setPhpsecConstants();
     }
 
     /**
@@ -89,6 +84,9 @@ class AccessToken
      *        to retrieve certificates, if not cached. This value should only be
      *        provided in limited circumstances in which you are sure of the
      *        behavior.
+     *     @type string $cacheKey The cache key of the cached certs. Defaults to
+     *        the sha1 of $certsLocation if provided, otherwise is set to
+     *        "federated_signon_certs_v3".
      * }
      * @return array|bool the token payload, if successful, or false if not.
      * @throws \InvalidArgumentException If certs could not be retrieved from a local file.
@@ -103,57 +101,129 @@ class AccessToken
         $certsLocation = isset($options['certsLocation'])
             ? $options['certsLocation']
             : self::FEDERATED_SIGNON_CERT_URL;
-
-        unset($options['audience'], $options['certsLocation']);
+        $cacheKey = isset($options['cacheKey'])
+            ? $options['cacheKey']
+            : $this->getCacheKeyFromCertLocation($certsLocation);
 
         // Check signature against each available cert.
         // allow the loop to complete unless a known bad result is encountered.
-        $certs = $this->getFederatedSignOnCerts($certsLocation, $options);
+        $certs = $this->getCerts($certsLocation, $cacheKey, $options);
+        $alg = $this->determineAlg($certs);
+
+        switch ($alg) {
+            case 'ES256':
+                return $this->verifyEs256($token, $certs, $audience);
+
+            case 'RS256':
+                return $this->verifyRs256($token, $certs, $audience);
+
+            default:
+                throw new \InvalidArgumentException(
+                    'unrecognized "alg" in certs, expected ES256 or RS256');
+        }
+    }
+
+    private function determineAlg($certs)
+    {
+        $keys = [];
+        $alg = null;
         foreach ($certs as $cert) {
+            if (empty($cert['alg'])) {
+                throw new \InvalidArgumentException(
+                    'certs expects "alg" to be set'
+                );
+            }
+            $alg = $alg ?: $cert['alg'];
+
+            if ($alg != $cert['alg']) {
+                throw new \InvalidArgumentException(
+                    'More than one alg detected in certs'
+                );
+            }
+        }
+        return $alg;
+    }
+
+    private function verifyEs256($token, $certs, $audience = null)
+    {
+        $this->checkSimpleJwt();
+
+        $jwkset = new KeySet();
+        foreach ($certs as $cert) {
+            $jwkset->add(KeyFactory::create($cert, 'php'));
+        }
+
+        // Validate the signature using the key set and ES256 algorithm.
+        try {
+            $jwt = $this->callSimpleJwtDecode([$token, $jwkset, 'ES256']);
+        } catch (InvalidTokenException $e) {
+            return false;
+        }
+
+        if ($aud = $jwt->getClaim('aud')) {
+            if ($audience && $aud != $audience) {
+                return false;
+            }
+        }
+
+        return $jwt->getClaims();
+    }
+
+    private function verifyRs256($token, $certs, $audience = null)
+    {
+        $this->checkAndInitializePhpsec();
+        $keys = [];
+        foreach ($certs as $cert) {
+            if (empty($cert['kid'])) {
+                throw new \InvalidArgumentException(
+                    'certs expects "kid" to be set'
+                );
+            }
+            if (empty($cert['n']) || empty($cert['e'])) {
+                throw new \InvalidArgumentException(
+                    'RSA certs expects "n" and "e" to be set'
+                );
+            }
             $rsa = new RSA();
             $rsa->loadKey([
                 'n' => new BigInteger($this->callJwtStatic('urlsafeB64Decode', [
-                    $cert['n']
+                    $cert['n'],
                 ]), 256),
                 'e' => new BigInteger($this->callJwtStatic('urlsafeB64Decode', [
                     $cert['e']
-                ]), 256)
+                ]), 256),
+            ]);
+            $keys[$cert['kid']] =  $rsa->getPublicKey();
+        }
+
+        try {
+            $payload = $this->callJwtStatic('decode', [
+                $token,
+                $keys,
+                ['RS256']
             ]);
 
-            try {
-                $pubkey = $rsa->getPublicKey();
-                $payload = $this->callJwtStatic('decode', [
-                    $token,
-                    $pubkey,
-                    ['RS256']
-                ]);
-
-                if (property_exists($payload, 'aud')) {
-                    if ($audience && $payload->aud != $audience) {
-                        return false;
-                    }
-                }
-
-                // support HTTP and HTTPS issuers
-                // @see https://developers.google.com/identity/sign-in/web/backend-auth
-                $issuers = [self::OAUTH2_ISSUER, self::OAUTH2_ISSUER_HTTPS];
-                if (!isset($payload->iss) || !in_array($payload->iss, $issuers)) {
+            if (property_exists($payload, 'aud')) {
+                if ($audience && $payload->aud != $audience) {
                     return false;
                 }
-
-                return (array) $payload;
-            } catch (ExpiredException $e) {
-                return false;
-            } catch (\ExpiredException $e) {
-                // (firebase/php-jwt 2)
-                return false;
-            } catch (SignatureInvalidException $e) {
-                // continue
-            } catch (\SignatureInvalidException $e) {
-                // continue (firebase/php-jwt 2)
-            } catch (\DomainException $e) {
-                // continue
             }
+
+            // support HTTP and HTTPS issuers
+            // @see https://developers.google.com/identity/sign-in/web/backend-auth
+            $issuers = [self::OAUTH2_ISSUER, self::OAUTH2_ISSUER_HTTPS];
+            if (!isset($payload->iss) || !in_array($payload->iss, $issuers)) {
+                return false;
+            }
+
+            return (array) $payload;
+        } catch (ExpiredException $e) {
+        } catch (\ExpiredException $e) {
+            // (firebase/php-jwt 2)
+        } catch (SignatureInvalidException $e) {
+        } catch (\SignatureInvalidException $e) {
+            // (firebase/php-jwt 2)
+        } catch (\DomainException $e) {
         }
 
         return false;
@@ -200,9 +270,9 @@ class AccessToken
      * @return array
      * @throws \InvalidArgumentException If received certs are in an invalid format.
      */
-    private function getFederatedSignOnCerts($location, array $options = [])
+    private function getCerts($location, $cacheKey, array $options = [])
     {
-        $cacheItem = $this->cache->getItem('federated_signon_certs_v3');
+        $cacheItem = $this->cache->getItem($cacheKey);
         $certs = $cacheItem ? $cacheItem->get() : null;
 
         $gotNewCerts = false;
@@ -213,8 +283,13 @@ class AccessToken
         }
 
         if (!isset($certs['keys'])) {
+            if ($location !== self::IAP_CERT_URL) {
+                throw new \InvalidArgumentException(
+                    'federated sign-on certs expects "keys" to be set'
+                );
+            }
             throw new \InvalidArgumentException(
-                'federated sign-on certs expects "keys" to be set'
+                'certs expects "keys" to be set'
             );
         }
 
@@ -234,7 +309,6 @@ class AccessToken
      *
      * @param $url string location
      * @param array $options [optional] Configuration options.
-     * @throws \RuntimeException
      * @return array certificates
      * @throws \InvalidArgumentException If certs could not be retrieved from a local file.
      * @throws \RuntimeException If certs could not be retrieved from a remote location.
@@ -266,20 +340,24 @@ class AccessToken
         ), $response->getStatusCode());
     }
 
-    /**
-     * Set required defaults for JWT.
-     */
-    private function configureJwtService()
+    private function checkAndInitializePhpsec()
     {
-        $class = class_exists('Firebase\JWT\JWT')
-            ? 'Firebase\JWT\JWT'
-            : '\JWT';
-
-        if (property_exists($class, 'leeway') && $class::$leeway < 1) {
-            // Ensures JWT leeway is at least 1
-            // @see https://github.com/google/google-api-php-client/issues/827
-            $class::$leeway = 1;
+        // @codeCoverageIgnoreStart
+        if (!class_exists(RSA::class)) {
+            throw new \RuntimeException('Please require phpseclib/phpseclib v2 to use this utility.');
         }
+        // @codeCoverageIgnoreEnd
+
+        $this->setPhpsecConstants();
+    }
+
+    private function checkSimpleJwt()
+    {
+        // @codeCoverageIgnoreStart
+        if (!class_exists(SimpleJWT::class)) {
+            throw new \RuntimeException('Please require kelvinmo/simplejwtlib ^0.2 to use this utility.');
+        }
+        // @codeCoverageIgnoreEnd
     }
 
     /**
@@ -316,5 +394,31 @@ class AccessToken
             ? 'Firebase\JWT\JWT'
             : 'JWT';
         return call_user_func_array([$class, $method], $args);
+    }
+
+    /**
+     * Provide a hook to mock calls to the JWT static methods.
+     *
+     * @param string $method
+     * @param array $args
+     * @return mixed
+     */
+    protected function callSimpleJwtDecode(array $args = [])
+    {
+        return call_user_func_array([SimpleJWT::class, 'decode'], $args);
+    }
+
+    /**
+     * Generate a cache key based on the cert location using sha1 with the
+     * exception of using "federated_signon_certs_v3" to preserve BC.
+     *
+     * @param string $certsLocation
+     * @return string
+     */
+    private function getCacheKeyFromCertLocation($certsLocation)
+    {
+        return $certsLocation === self::FEDERATED_SIGNON_CERT_URL
+            ? 'federated_signon_certs_v3'
+            : sha1($certsLocation);
     }
 }

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -130,9 +130,8 @@ class AccessToken
      *                     https://tools.ietf.org/html/rfc7517).
      * @return string The expected algorithm, such as "ES256" or "RS256".
      */
-    private function determineAlg($certs)
+    private function determineAlg(array $certs)
     {
-        $keys = [];
         $alg = null;
         foreach ($certs as $cert) {
             if (empty($cert['alg'])) {
@@ -162,7 +161,7 @@ class AccessToken
      *                              the JWT.
      * @return array|bool the token payload, if successful, or false if not.
      */
-    private function verifyEs256($token, $certs, $audience = null)
+    private function verifyEs256($token, array $certs, $audience = null)
     {
         $this->checkSimpleJwt();
 

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -197,7 +197,7 @@ class AccessToken
      *                              the JWT.
      * @return array|bool the token payload, if successful, or false if not.
      */
-    private function verifyRs256($token, $certs, $audience = null)
+    private function verifyRs256($token, array $certs, $audience = null)
     {
         $this->checkAndInitializePhpsec();
         $keys = [];

--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -18,7 +18,7 @@
 namespace Google\Auth\Tests;
 
 use Firebase\JWT\ExpiredException;
-use Firebase\JWT\JWT;
+use Firebase\JWT\JWT as FirebaseJWT;
 use Firebase\JWT\SignatureInvalidException;
 use Google\Auth\AccessToken;
 use GuzzleHttp\Psr7\Response;
@@ -26,6 +26,7 @@ use phpseclib\Crypt\RSA;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
+use SimpleJWT\JWT as SimpleJWT;
 
 /**
  * @group access-token
@@ -62,7 +63,8 @@ class AccessTokenTest extends TestCase
         $payload,
         $expected,
         $audience = null,
-        callable $verifyCallback = null
+        callable $verifyCallback = null,
+        $certsLocation = null
     ) {
         $item = $this->prophesize('Psr\Cache\CacheItemInterface');
         $item->get()->willReturn([
@@ -78,14 +80,14 @@ class AccessTokenTest extends TestCase
             ]
         ]);
 
-        $this->cache->getItem('federated_signon_certs_v3')
+        $cacheKey = $certsLocation ? sha1($certsLocation) : 'federated_signon_certs_v3';
+        $this->cache->getItem($cacheKey)
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
         $token = new AccessTokenStub(
             null,
-            $this->cache->reveal(),
-            $this->jwt->reveal()
+            $this->cache->reveal()
         );
 
         $token->mocks['decode'] = function ($token, $publicKey, $allowedAlgs) use ($payload, $verifyCallback) {
@@ -100,7 +102,8 @@ class AccessTokenTest extends TestCase
         };
 
         $res = $token->verify($this->token, [
-            'audience' => $audience
+            'audience' => $audience,
+            'certsLocation' => $certsLocation,
         ]);
         $this->assertEquals($expected, $res);
     }
@@ -161,8 +164,43 @@ class AccessTokenTest extends TestCase
                 function () {
                     throw new \DomainException('expired!');
                 }
-            ]
+            ],
+            [
+                $this->payload,
+                $this->payload,
+                null,
+                null,
+                AccessToken::IAP_CERT_URL
+            ],
         ];
+    }
+
+    public function testEsVerifyEndToEnd()
+    {
+        if (!$jwt = getenv('IAP_IDENTITY_TOKEN')) {
+            $this->markTestSkipped('Set the IAP_IDENTITY_TOKEN env var');
+        }
+
+        $token = new AccessTokenStub();
+        $token->mocks['simpleJwtDecode'] = function ($token, $publicKey, $allowedAlgs) {
+            // Skip expired validation
+            return SimpleJWT::decode(
+                $token,
+                $publicKey,
+                $allowedAlgs,
+                null,
+                ['exp']
+            );
+        };
+
+        // Use Iap Cert URL
+        $payload = $token->verify($jwt, [
+            'certsLocation' => AccessToken::IAP_CERT_URL,
+        ]);
+
+        $this->assertNotFalse($payload);
+        $this->assertArrayHasKey('iss', $payload);
+        $this->assertEquals('https://cloud.google.com/iap', $payload['iss']);
     }
 
     public function testRetrieveCertsFromLocationLocalFile()
@@ -179,7 +217,7 @@ class AccessTokenTest extends TestCase
         $item->expiresAt(Argument::type('\DateTime'))
             ->shouldBeCalledTimes(1);
 
-        $this->cache->getItem('federated_signon_certs_v3')
+        $this->cache->getItem(sha1($certsLocation))
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
@@ -188,8 +226,7 @@ class AccessTokenTest extends TestCase
 
         $token = new AccessTokenStub(
             null,
-            $this->cache->reveal(),
-            $this->jwt->reveal()
+            $this->cache->reveal()
         );
 
         $token->mocks['decode'] = function ($token, $publicKey, $allowedAlgs) {
@@ -217,19 +254,41 @@ class AccessTokenTest extends TestCase
             ->shouldBeCalledTimes(1)
             ->willReturn(null);
 
+        $this->cache->getItem(sha1($certsLocation))
+            ->shouldBeCalledTimes(1)
+            ->willReturn($item->reveal());
+
+        $token = new AccessTokenStub(
+            null,
+            $this->cache->reveal()
+        );
+
+        $token->verify($this->token, [
+            'certsLocation' => $certsLocation
+        ]);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage federated sign-on certs expects "keys" to be set
+     */
+    public function testRetrieveCertsInvalidData()
+    {
+        $item = $this->prophesize('Psr\Cache\CacheItemInterface');
+        $item->get()
+            ->shouldBeCalledTimes(1)
+            ->willReturn('{}');
+
         $this->cache->getItem('federated_signon_certs_v3')
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
         $token = new AccessTokenStub(
             null,
-            $this->cache->reveal(),
-            $this->jwt->reveal()
+            $this->cache->reveal()
         );
 
-        $token->verify($this->token, [
-            'certsLocation' => $certsLocation
-        ]);
+        $token->verify($this->token);
     }
 
     /**
@@ -247,14 +306,13 @@ class AccessTokenTest extends TestCase
             ->shouldBeCalledTimes(1)
             ->willReturn(null);
 
-        $this->cache->getItem('federated_signon_certs_v3')
+        $this->cache->getItem(sha1($certsLocation))
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
         $token = new AccessTokenStub(
             null,
-            $this->cache->reveal(),
-            $this->jwt->reveal()
+            $this->cache->reveal()
         );
 
         $token->verify($this->token, [
@@ -293,8 +351,7 @@ class AccessTokenTest extends TestCase
 
         $token = new AccessTokenStub(
             $httpHandler,
-            $this->cache->reveal(),
-            $this->jwt->reveal()
+            $this->cache->reveal()
         );
 
         $token->mocks['decode'] = function ($token, $publicKey, $allowedAlgs) {
@@ -396,6 +453,13 @@ class AccessTokenStub extends AccessToken
         return isset($this->mocks[$method])
             ? call_user_func_array($this->mocks[$method], $args)
             : parent::callJwtStatic($method, $args);
+    }
+
+    protected function callSimpleJwtDecode(array $args = [])
+    {
+        return isset($this->mocks['simpleJwtDecode'])
+            ? call_user_func_array($this->mocks['simpleJwtDecode'], $args)
+            : parent::callSimpleJwtDecode($args);
     }
 }
 //@codingStandardsIgnoreEnd

--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -80,7 +80,8 @@ class AccessTokenTest extends TestCase
             ]
         ]);
 
-        $cacheKey = $certsLocation ? sha1($certsLocation) : 'federated_signon_certs_v3';
+        $cacheKey = 'google_auth_certs_cache:' .
+            ($certsLocation ? sha1($certsLocation) : 'federated_signon_certs_v3');
         $this->cache->getItem($cacheKey)
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
@@ -217,7 +218,7 @@ class AccessTokenTest extends TestCase
         $item->expiresAt(Argument::type('\DateTime'))
             ->shouldBeCalledTimes(1);
 
-        $this->cache->getItem(sha1($certsLocation))
+        $this->cache->getItem('google_auth_certs_cache:' . sha1($certsLocation))
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
@@ -254,7 +255,7 @@ class AccessTokenTest extends TestCase
             ->shouldBeCalledTimes(1)
             ->willReturn(null);
 
-        $this->cache->getItem(sha1($certsLocation))
+        $this->cache->getItem('google_auth_certs_cache:' . sha1($certsLocation))
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
@@ -279,7 +280,7 @@ class AccessTokenTest extends TestCase
             ->shouldBeCalledTimes(1)
             ->willReturn('{}');
 
-        $this->cache->getItem('federated_signon_certs_v3')
+        $this->cache->getItem('google_auth_certs_cache:federated_signon_certs_v3')
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
@@ -306,7 +307,7 @@ class AccessTokenTest extends TestCase
             ->shouldBeCalledTimes(1)
             ->willReturn(null);
 
-        $this->cache->getItem(sha1($certsLocation))
+        $this->cache->getItem('google_auth_certs_cache:' . sha1($certsLocation))
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
@@ -342,7 +343,7 @@ class AccessTokenTest extends TestCase
         $item->expiresAt(Argument::type('\DateTime'))
             ->shouldBeCalledTimes(1);
 
-        $this->cache->getItem('federated_signon_certs_v3')
+        $this->cache->getItem('google_auth_certs_cache:federated_signon_certs_v3')
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
@@ -381,7 +382,7 @@ class AccessTokenTest extends TestCase
             ->shouldBeCalledTimes(1)
             ->willReturn(null);
 
-        $this->cache->getItem('federated_signon_certs_v3')
+        $this->cache->getItem('google_auth_certs_cache:federated_signon_certs_v3')
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 


### PR DESCRIPTION
Verify an IAP token:

```php
use Google\Auth\AccessToken;

$token = new AccessToken();
$result = $token->verify($iapJwt, [
    'certsLocation' => AccessToken::IAP_CERT_URL
]);
```

Some points of interest:

 - The cache key, when `certsLocation` is set, is now a `sha1` of the location, to prevent collisions with multiple cert types
 - Added a `cacheKey` option to override this in the `$options` array argument to `verify`
 - The exceptions have changed slightly - when `IAP_CERT_URL` is provided as the `certLocation`, the message `federated sign-on certs expect "keys" to be set` now reads `certs expect "keys" to be set`. This is because the IAP certs are not federated sign-on certs.
 - `ES256` verification requires the use of the library `kelvinmo/simplejwt`, which is in a pre-1.0 state. 