### PR TITLE
feat: Add support for Guzzle 7.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,27 @@ jobs:
                 command: composer update --prefer-lowest
             - name: Run Script
               run: vendor/bin/phpunit
+    guzzle6:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                operating-system: [ ubuntu-latest ]
+                php: [ "5.6", "7.2" ]
+        name: PHP ${{ matrix.php }} Unit Test Guzzle 6
+        steps:
+            - uses: actions/checkout@v2
+            - name: Setup PHP
+              uses: nanasess/setup-php@v3.0.4
+              with:
+                php-version: ${{ matrix.php }}
+            - name: Install Dependencies
+              uses: nick-invision/retry@v1
+              with:
+                timeout_minutes: 10
+                max_attempts: 3
+                command: composer require guzzlehttp/guzzle:^6 && composer update
+            - name: Run Script
+              run: vendor/bin/phpunit
     # use dockerfiles for oooooolllllldddd versions of php, setup-php times out for those.
     test_php55:
         name: "PHP 5.5 Unit Test"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require": {
     "php": ">=5.4",
     "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",
-    "guzzlehttp/guzzle": "~5.3.1|~6.0",
+    "guzzlehttp/guzzle": "^5.3.1|^6.0|^7.0",
     "guzzlehttp/psr7": "^1.2",
     "psr/http-message": "^1.0",
     "psr/cache": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require": {
     "php": ">=5.4",
     "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",
-    "guzzlehttp/guzzle": "^5.3.1|^6.0|^7.0",
+    "guzzlehttp/guzzle": "^5.3.1|^6.2.1|^7.0",
     "guzzlehttp/psr7": "^1.2",
     "psr/http-message": "^1.0",
     "psr/cache": "^1.0"

--- a/src/HttpHandler/Guzzle6HttpHandler.php
+++ b/src/HttpHandler/Guzzle6HttpHandler.php
@@ -1,5 +1,19 @@
 <?php
-
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace Google\Auth\HttpHandler;
 
 use GuzzleHttp\ClientInterface;

--- a/src/HttpHandler/Guzzle7HttpHandler.php
+++ b/src/HttpHandler/Guzzle7HttpHandler.php
@@ -1,12 +1,12 @@
 <?php
-/*
- * Copyright 2010 Google Inc.
+/**
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,26 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+namespace Google\Auth\HttpHandler;
 
-namespace Google\Auth\Tests\Middleware;
-
-use Google\Auth\Tests\BaseTest;
-
-class SimpleMiddlewareTest extends BaseTest
+class Guzzle7HttpHandler extends Guzzle6HttpHandler
 {
-    private $mockRequest;
-
-    /**
-     * @todo finish
-     */
-    protected function setUp()
-    {
-        $this->onlyGuzzle6And7();
-
-        $this->mockRequest = $this->prophesize('GuzzleHttp\Psr7\Request');
-    }
-
-    public function testTest()
-    {
-    }
 }

--- a/src/HttpHandler/HttpHandlerFactory.php
+++ b/src/HttpHandler/HttpHandlerFactory.php
@@ -25,19 +25,27 @@ class HttpHandlerFactory
      * Builds out a default http handler for the installed version of guzzle.
      *
      * @param ClientInterface $client
-     * @return Guzzle5HttpHandler|Guzzle6HttpHandler
+     * @return Guzzle5HttpHandler|Guzzle6HttpHandler|Guzzle7HttpHandler
      * @throws \Exception
      */
     public static function build(ClientInterface $client = null)
     {
-        $version = ClientInterface::VERSION;
         $client = $client ?: new Client();
 
-        switch ($version[0]) {
-            case '5':
+        $version = null;
+        if (defined('GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
+            $version = ClientInterface::MAJOR_VERSION;
+        } elseif (defined('GuzzleHttp\ClientInterface::VERSION')) {
+            $version = (int) substr(ClientInterface::VERSION, 0, 1);
+        }
+
+        switch ($version) {
+            case 5:
                 return new Guzzle5HttpHandler($client);
-            case '6':
+            case 6:
                 return new Guzzle6HttpHandler($client);
+            case 7:
+                return new Guzzle7HttpHandler($client);
             default:
                 throw new \Exception('Version not supported');
         }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -7,20 +7,45 @@ use PHPUnit\Framework\TestCase;
 
 abstract class BaseTest extends TestCase
 {
-    public function onlyGuzzle6()
+    protected function onlyGuzzle5()
     {
-        $version = ClientInterface::VERSION;
-        if ('6' !== $version[0]) {
+        if ($this->getGuzzleMajorVersion() !== 5) {
+            $this->markTestSkipped('Guzzle 5 only');
+        }
+    }
+
+    protected function onlyGuzzle6()
+    {
+        if ($this->getGuzzleMajorVersion() !== 6) {
             $this->markTestSkipped('Guzzle 6 only');
         }
     }
 
-    public function onlyGuzzle5()
+    protected function onlyGuzzle6And7()
     {
-        $version = ClientInterface::VERSION;
-        if ('5' !== $version[0]) {
-            $this->markTestSkipped('Guzzle 5 only');
+        if (!in_array($this->getGuzzleMajorVersion(), [6, 7])) {
+            $this->markTestSkipped('Guzzle 6 and 7 only');
         }
+    }
+
+    protected function onlyGuzzle7()
+    {
+        if ($this->getGuzzleMajorVersion() !== 7) {
+            $this->markTestSkipped('Guzzle 7 only');
+        }
+    }
+
+    protected function getGuzzleMajorVersion()
+    {
+        if (defined('GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
+            return ClientInterface::MAJOR_VERSION;
+        }
+
+        if (defined('GuzzleHttp\ClientInterface::VERSION')) {
+            return (int) substr(ClientInterface::VERSION, 0, 1);
+        }
+
+        $this->fail('Unable to determine the currently used Guzzle Version');
     }
 
     /**

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -19,16 +19,15 @@ namespace Google\Auth\Tests\Credentials;
 
 use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\HttpHandler\HttpClientCache;
-use GuzzleHttp\ClientInterface;
+use Google\Auth\Tests\BaseTest;
 use GuzzleHttp\Psr7;
-use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
 /**
  * @group credentials
  * @group credentials-gce
  */
-class GCECredentialsTest extends TestCase
+class GCECredentialsTest extends BaseTest
 {
     public function testOnGceMetadataFlavorHeader()
     {
@@ -182,10 +181,7 @@ class GCECredentialsTest extends TestCase
      */
     public function testFetchAuthTokenCustomScope($scope, $expected)
     {
-        $guzzleVersion = ClientInterface::VERSION;
-        if ($guzzleVersion[0] === '5') {
-            $this->markTestSkipped('Only compatible with guzzle 6+');
-        }
+        $this->onlyGuzzle6And7();
 
         $uri = null;
         $client = $this->prophesize('GuzzleHttp\ClientInterface');
@@ -258,10 +254,7 @@ class GCECredentialsTest extends TestCase
 
     public function testSignBlob()
     {
-        $guzzleVersion = ClientInterface::VERSION;
-        if ($guzzleVersion[0] === '5') {
-            $this->markTestSkipped('Only compatible with guzzle 6+');
-        }
+        $this->onlyGuzzle6And7();
 
         $expectedEmail = 'test@test.com';
         $expectedAccessToken = 'token';
@@ -294,10 +287,7 @@ class GCECredentialsTest extends TestCase
 
     public function testSignBlobWithLastReceivedAccessToken()
     {
-        $guzzleVersion = ClientInterface::VERSION;
-        if ($guzzleVersion[0] === '5') {
-            $this->markTestSkipped('Only compatible with guzzle 6+');
-        }
+        $this->onlyGuzzle6And7();
 
         $expectedEmail = 'test@test.com';
         $expectedAccessToken = 'token';
@@ -340,10 +330,7 @@ class GCECredentialsTest extends TestCase
 
     public function testGetProjectId()
     {
-        $guzzleVersion = ClientInterface::VERSION;
-        if ($guzzleVersion[0] === '5') {
-            $this->markTestSkipped('Only compatible with guzzle 6+');
-        }
+        $this->onlyGuzzle6And7();
 
         $expected = 'foobar';
 
@@ -366,10 +353,7 @@ class GCECredentialsTest extends TestCase
 
     public function testGetProjectIdShouldBeEmptyIfNotOnGCE()
     {
-        $guzzleVersion = ClientInterface::VERSION;
-        if ($guzzleVersion[0] === '5') {
-            $this->markTestSkipped('Only compatible with guzzle 6+');
-        }
+        $this->onlyGuzzle6And7();
 
         // simulate retry attempts by returning multiple 500s
         $client = $this->prophesize('GuzzleHttp\ClientInterface');

--- a/tests/FetchAuthTokenTest.php
+++ b/tests/FetchAuthTokenTest.php
@@ -61,14 +61,21 @@ class FetchAuthTokenTest extends BaseTest
             $this->assertEquals('xyz', $accessToken);
         };
 
+        if ($this->getGuzzleMajorVersion() === 5) {
+            $clientOptions = [
+                'base_url' => 'https://www.googleapis.com/books/v1/',
+                'defaults' => ['exceptions' => false],
+            ];
+        } else {
+            $clientOptions = [
+                'base_uri' => 'https://www.googleapis.com/books/v1/',
+                'http_errors' => false,
+            ];
+        }
+
         $client = CredentialsLoader::makeHttpClient(
             $mockFetcher->reveal(),
-            [
-                'base_url' => 'https://www.googleapis.com/books/v1/',
-                'base_uri' => 'https://www.googleapis.com/books/v1/',
-                'exceptions' => false,
-                'defaults' => ['exceptions' => false]
-            ],
+            $clientOptions,
             $httpHandler,
             $tokenCallback
         );

--- a/tests/HttpHandler/Guzzle7HttpHandlerTest.php
+++ b/tests/HttpHandler/Guzzle7HttpHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2010 Google Inc.
+ * Copyright 2020 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,25 +15,20 @@
  * limitations under the License.
  */
 
-namespace Google\Auth\Tests\Middleware;
+namespace Google\Auth\Tests\HttpHandler;
 
-use Google\Auth\Tests\BaseTest;
+use Google\Auth\HttpHandler\Guzzle7HttpHandler;
 
-class SimpleMiddlewareTest extends BaseTest
+/**
+ * @group http-handler
+ */
+class Guzzle7HttpHandlerTest extends Guzzle6HttpHandlerTest
 {
-    private $mockRequest;
-
-    /**
-     * @todo finish
-     */
-    protected function setUp()
+    public function setUp()
     {
-        $this->onlyGuzzle6And7();
+        $this->onlyGuzzle7();
 
-        $this->mockRequest = $this->prophesize('GuzzleHttp\Psr7\Request');
-    }
-
-    public function testTest()
-    {
+        $this->client = $this->prophesize('GuzzleHttp\ClientInterface');
+        $this->handler = new Guzzle7HttpHandler($this->client->reveal());
     }
 }

--- a/tests/HttpHandler/HttpHandlerFactoryTest.php
+++ b/tests/HttpHandler/HttpHandlerFactoryTest.php
@@ -40,4 +40,13 @@ class HttpHandlerFactoryTest extends BaseTest
         $handler = HttpHandlerFactory::build();
         $this->assertInstanceOf('Google\Auth\HttpHandler\Guzzle6HttpHandler', $handler);
     }
+
+    public function testBuildsGuzzle7Handler()
+    {
+        $this->onlyGuzzle7();
+
+        HttpClientCache::setHttpClient(null);
+        $handler = HttpHandlerFactory::build();
+        $this->assertInstanceOf('Google\Auth\HttpHandler\Guzzle7HttpHandler', $handler);
+    }
 }

--- a/tests/Middleware/AuthTokenMiddlewareTest.php
+++ b/tests/Middleware/AuthTokenMiddlewareTest.php
@@ -33,7 +33,7 @@ class AuthTokenMiddlewareTest extends BaseTest
 
     protected function setUp()
     {
-        $this->onlyGuzzle6();
+        $this->onlyGuzzle6And7();
 
         $this->mockFetcher = $this->prophesize('Google\Auth\FetchAuthTokenInterface');
         $this->mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');

--- a/tests/Middleware/ScopedAccessTokenMiddlewareTest.php
+++ b/tests/Middleware/ScopedAccessTokenMiddlewareTest.php
@@ -33,7 +33,7 @@ class ScopedAccessTokenMiddlewareTest extends BaseTest
 
     protected function setUp()
     {
-        $this->onlyGuzzle6();
+        $this->onlyGuzzle6And7();
 
         $this->mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
         $this->mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');


### PR DESCRIPTION
Greetings 👋

**Update 2020-06-27: [Guzzle 7.0 has been released](https://github.com/guzzle/guzzle/releases)**

Guzzle 7 is only in beta at the moment, but due to its popularity/once it's released I assume that many developers will want to use it, perhaps already today. This PR aims to make google/auth ready for that and is a prerequisite to making similar changes to [`google/cloud(-core)`](https://github.com/googleapis/google-cloud-php) and [`google/api-client`](https://github.com/googleapis/google-api-php-client).

### Changes

- Updated composer.json
- ~Extracted a version helper into a dedicated method in `HttpHandlerFactory::getGuzzleVersion()` and replaced usages~ _(Reverted after review)_ 
- ~Updated test matrix to test all supported Guzzle Versions (5.x is covered by `--prefer-lowest`, 6.x by the new environment, 7.x by default)~ _(The tests have moved to GitHub Actions since)_
- Updated the check itself: ~According to https://github.com/guzzle/guzzle/blob/7.0.0-beta.1/UPGRADING.md#other-backwards-compatibility-breaking-changes , the `ClientInterface::VERSION` constant has been removed - that means that we can safely assume that a missing constant means that we're on 7.x~ Guzzle 7 has introduced `ClientInterface::MAJOR_VERSION` that can be used for version checks.
- Changed the HTTP client option `exceptions` to `http_errors` for tests with Guzzle >=6.0 (support for `exceptions` has been removed in Guzzle 7)

:octocat: 