### PR TITLE
fix: let namespace match the file structure

### DIFF
--- a/tests/Credentials/AppIdentityCredentialsTest.php
+++ b/tests/Credentials/AppIdentityCredentialsTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Auth\Tests\Cache;
+namespace Google\Auth\Tests\Credentials;
 
 use google\appengine\api\app_identity\AppIdentityService;
 // included from tests\mocks\AppIdentityService.php

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Auth\Tests\Cache;
+namespace Google\Auth\Tests\Credentials;
 
 use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\HttpHandler\HttpClientCache;

--- a/tests/Credentials/IAMCredentialsTest.php
+++ b/tests/Credentials/IAMCredentialsTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Auth\Tests\Cache;
+namespace Google\Auth\Tests\Credentials;
 
 use Google\Auth\Credentials\IAMCredentials;
 use PHPUnit\Framework\TestCase;

--- a/tests/Credentials/InsecureCredentialsTest.php
+++ b/tests/Credentials/InsecureCredentialsTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Auth\Tests\Cache;
+namespace Google\Auth\Tests\Credentials;
 
 use Google\Auth\Credentials\InsecureCredentials;
 use PHPUnit\Framework\TestCase;

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Auth\Tests\Cache;
+namespace Google\Auth\Tests\Credentials;
 
 use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Credentials\ServiceAccountCredentials;

--- a/tests/Credentials/UserRefreshCredentialsTest.php
+++ b/tests/Credentials/UserRefreshCredentialsTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Auth\Tests\Cache;
+namespace Google\Auth\Tests\Credentials;
 
 use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Credentials\UserRefreshCredentials;


### PR DESCRIPTION
The test suite is file-based so this didn't throw an error, but since the classes in the tests folder are referenced in the composer.json in the autoload-dev section, we can prevent problems in the future 🤞

:octocat: 