### PR TITLE
fix: invalid character in iap cert cache key

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -450,6 +450,6 @@ class AccessToken
             ? 'federated_signon_certs_v3'
             : sha1($certsLocation);
 
-        return 'google_auth_certs_cache:' . $key;
+        return 'google_auth_certs_cache|' . $key;
     }
 }

--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -218,9 +218,8 @@ class AccessTokenTest extends TestCase
             AccessToken::IAP_CERT_URL,
             $cacheKey
         );
-
         $this->assertTrue(is_array($certs));
-        $this->assertArrayHasKey('keys', $certs);
+        $this->assertEquals(5, count($certs));
     }
 
     public function testRetrieveCertsFromLocationLocalFile()

--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -80,7 +80,7 @@ class AccessTokenTest extends TestCase
             ]
         ]);
 
-        $cacheKey = 'google_auth_certs_cache:' .
+        $cacheKey = 'google_auth_certs_cache|' .
             ($certsLocation ? sha1($certsLocation) : 'federated_signon_certs_v3');
         $this->cache->getItem($cacheKey)
             ->shouldBeCalledTimes(1)
@@ -204,6 +204,25 @@ class AccessTokenTest extends TestCase
         $this->assertEquals('https://cloud.google.com/iap', $payload['iss']);
     }
 
+    public function testGetCertsForIap()
+    {
+        $token = new AccessToken();
+        $reflector = new \ReflectionObject($token);
+        $cacheKeyMethod = $reflector->getMethod('getCacheKeyFromCertLocation');
+        $cacheKeyMethod->setAccessible(true);
+        $getCertsMethod = $reflector->getMethod('getCerts');
+        $getCertsMethod->setAccessible(true);
+        $cacheKey = $cacheKeyMethod->invoke($token, AccessToken::IAP_CERT_URL);
+        $certs = $getCertsMethod->invoke(
+            $token,
+            AccessToken::IAP_CERT_URL,
+            $cacheKey
+        );
+
+        $this->assertTrue(is_array($certs));
+        $this->assertArrayHasKey('keys', $certs);
+    }
+
     public function testRetrieveCertsFromLocationLocalFile()
     {
         $certsLocation = __DIR__ . '/fixtures/federated-certs.json';
@@ -218,7 +237,7 @@ class AccessTokenTest extends TestCase
         $item->expiresAt(Argument::type('\DateTime'))
             ->shouldBeCalledTimes(1);
 
-        $this->cache->getItem('google_auth_certs_cache:' . sha1($certsLocation))
+        $this->cache->getItem('google_auth_certs_cache|' . sha1($certsLocation))
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
@@ -255,7 +274,7 @@ class AccessTokenTest extends TestCase
             ->shouldBeCalledTimes(1)
             ->willReturn(null);
 
-        $this->cache->getItem('google_auth_certs_cache:' . sha1($certsLocation))
+        $this->cache->getItem('google_auth_certs_cache|' . sha1($certsLocation))
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
@@ -280,7 +299,7 @@ class AccessTokenTest extends TestCase
             ->shouldBeCalledTimes(1)
             ->willReturn('{}');
 
-        $this->cache->getItem('google_auth_certs_cache:federated_signon_certs_v3')
+        $this->cache->getItem('google_auth_certs_cache|federated_signon_certs_v3')
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
@@ -307,7 +326,7 @@ class AccessTokenTest extends TestCase
             ->shouldBeCalledTimes(1)
             ->willReturn(null);
 
-        $this->cache->getItem('google_auth_certs_cache:' . sha1($certsLocation))
+        $this->cache->getItem('google_auth_certs_cache|' . sha1($certsLocation))
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
@@ -343,7 +362,7 @@ class AccessTokenTest extends TestCase
         $item->expiresAt(Argument::type('\DateTime'))
             ->shouldBeCalledTimes(1);
 
-        $this->cache->getItem('google_auth_certs_cache:federated_signon_certs_v3')
+        $this->cache->getItem('google_auth_certs_cache|federated_signon_certs_v3')
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 
@@ -382,7 +401,7 @@ class AccessTokenTest extends TestCase
             ->shouldBeCalledTimes(1)
             ->willReturn(null);
 
-        $this->cache->getItem('google_auth_certs_cache:federated_signon_certs_v3')
+        $this->cache->getItem('google_auth_certs_cache|federated_signon_certs_v3')
             ->shouldBeCalledTimes(1)
             ->willReturn($item->reveal());
 


### PR DESCRIPTION
Woops, `:` is an invalid cache-key character according to PSR-0. Changing it to `|`.