### PR TITLE
feat: add option to specify issuer in AccessToken::verify

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -215,7 +215,7 @@ class AccessToken
         }
 
         // @see https://cloud.google.com/iap/docs/signed-headers-howto#verifying_the_jwt_payload
-        $issuer = isset($issuer) ? $issuer : self::IAP_ISSUER;
+        $issuer = $issuer ?: self::IAP_ISSUER;
         if (!isset($payload['iss']) || $payload['iss'] !== $issuer) {
             throw new UnexpectedValueException('Issuer does not match');
         }

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -280,7 +280,7 @@ class AccessToken
 
         // support HTTP and HTTPS issuers
         // @see https://developers.google.com/identity/sign-in/web/backend-auth
-        $issuers = isset($issuer) ? array($issuer) : [self::OAUTH2_ISSUER, self::OAUTH2_ISSUER_HTTPS];
+        $issuers = $issuer ? [$issuer] : [self::OAUTH2_ISSUER, self::OAUTH2_ISSUER_HTTPS];
         if (!isset($payload->iss) || !in_array($payload->iss, $issuers)) {
             throw new UnexpectedValueException('Issuer does not match');
         }

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -190,6 +190,9 @@ class AccessToken
      * @param string|null $audience If set, returns false if the provided
      *                              audience does not match the "aud" claim on
      *                              the JWT.
+     * @param string|null $issuer If set, returns false if the provided
+     *                            issuer does not match the "iss" claim on
+     *                            the JWT.
      * @return array|bool the token payload, if successful, or false if not.
      */
     private function verifyEs256($token, array $certs, $audience = null, $issuer = null)
@@ -229,6 +232,9 @@ class AccessToken
      * @param string|null $audience If set, returns false if the provided
      *                              audience does not match the "aud" claim on
      *                              the JWT.
+     * @param string|null $issuer If set, returns false if the provided
+     *                            issuer does not match the "iss" claim on
+     *                            the JWT.
      * @return array|bool the token payload, if successful, or false if not.
      */
     private function verifyRs256($token, array $certs, $audience = null, $issuer = null)

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -135,7 +135,7 @@ class AccessToken
             if ($alg == 'RS256') {
                 return $this->verifyRs256($token, $certs, $audience, $issuer);
             }
-            return $this->verifyEs256($token, $certs, $audience);
+            return $this->verifyEs256($token, $certs, $audience, $issuer);
         } catch (ExpiredException $e) {  // firebase/php-jwt 3+
         } catch (\ExpiredException $e) { // firebase/php-jwt 2
         } catch (SignatureInvalidException $e) {  // firebase/php-jwt 3+
@@ -192,7 +192,7 @@ class AccessToken
      *                              the JWT.
      * @return array|bool the token payload, if successful, or false if not.
      */
-    private function verifyEs256($token, array $certs, $audience = null)
+    private function verifyEs256($token, array $certs, $audience = null, $issuer = null)
     {
         $this->checkSimpleJwt();
 
@@ -212,7 +212,8 @@ class AccessToken
         }
 
         // @see https://cloud.google.com/iap/docs/signed-headers-howto#verifying_the_jwt_payload
-        if (!isset($payload['iss']) || $payload['iss'] !== self::IAP_ISSUER) {
+        $issuer = isset($issuer) ? $issuer : self::IAP_ISSUER;
+        if (!isset($payload['iss']) || $payload['iss'] !== $issuer) {
             throw new UnexpectedValueException('Issuer does not match');
         }
 

--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -201,6 +201,24 @@ class AccessTokenTest extends TestCase
                 'bar',
                 null,
                 AccessToken::IAP_CERT_URL
+            ], [
+                [
+                    'iss' => 'baz'
+                ] + $this->payload,
+                false,
+                null,
+                null,
+                AccessToken::IAP_CERT_URL
+            ], [
+                [
+                    'iss' => 'baz'
+                ] + $this->payload, [
+                    'iss' => 'baz'
+                ] + $this->payload,
+                null,
+                null,
+                AccessToken::IAP_CERT_URL,
+                'baz'
             ]
         ];
     }

--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -59,7 +59,8 @@ class AccessTokenTest extends TestCase
         $expected,
         $audience = null,
         $exception = null,
-        $certsLocation = null
+        $certsLocation = null,
+        $issuer = null
     ) {
         $item = $this->prophesize('Psr\Cache\CacheItemInterface');
         $item->get()->willReturn([
@@ -101,6 +102,7 @@ class AccessTokenTest extends TestCase
         try {
             $res = $token->verify($this->token, [
                 'audience' => $audience,
+                'issuer' => $issuer,
                 'certsLocation' => $certsLocation,
                 'throwException' => (bool) $exception,
             ]);
@@ -146,6 +148,17 @@ class AccessTokenTest extends TestCase
                     'iss' => 'invalid'
                 ] + $this->payload,
                 false
+            ], [
+                [
+                    'iss' => 'baz'
+                ] + $this->payload,
+                [
+                    'iss' => 'baz'
+                ] + $this->payload,
+                null,
+                null,
+                null,
+                'baz'
             ], [
                 $this->payload,
                 false,


### PR DESCRIPTION
This allows issuer to be passed to AccessToken::verify, providing support for any JWTs