### PR TITLE
Refactor CacheTrait to enable expiration tracking

### DIFF
--- a/tests/Middleware/AuthTokenMiddlewareTest.php
+++ b/tests/Middleware/AuthTokenMiddlewareTest.php
@@ -27,8 +27,6 @@ use Prophecy\Argument;
 class AuthTokenMiddlewareTest extends BaseTest
 {
     private $mockFetcher;
-    private $mockCacheItem;
-    private $mockCache;
     private $mockRequest;
 
     protected function setUp()
@@ -36,8 +34,6 @@ class AuthTokenMiddlewareTest extends BaseTest
         $this->onlyGuzzle6And7();
 
         $this->mockFetcher = $this->prophesize('Google\Auth\FetchAuthTokenInterface');
-        $this->mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
-        $this->mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
         $this->mockRequest = $this->prophesize('GuzzleHttp\Psr7\Request');
     }
 
@@ -101,165 +97,38 @@ class AuthTokenMiddlewareTest extends BaseTest
         $callable($this->mockRequest->reveal(), ['auth' => 'google_auth']);
     }
 
-    public function testUsesCachedAuthToken()
-    {
-        $cacheKey = 'myKey';
-        $cachedValue = '2/abcdef1234567890';
-        $this->mockCacheItem->isHit()
-            ->shouldBeCalledTimes(1)
-            ->willReturn(true);
-        $this->mockCacheItem->get()
-            ->shouldBeCalledTimes(1)
-            ->willReturn($cachedValue);
-        $this->mockCache->getItem($cacheKey)
-            ->shouldBeCalledTimes(1)
-            ->willReturn($this->mockCacheItem->reveal());
-        $this->mockFetcher->fetchAuthToken()
-            ->shouldNotBeCalled();
-        $this->mockFetcher->getCacheKey()
-            ->shouldBeCalled()
-            ->willReturn($cacheKey);
-        $this->mockRequest->withHeader('authorization', 'Bearer ' . $cachedValue)
-            ->shouldBeCalledTimes(1)
-            ->willReturn($this->mockRequest->reveal());
-
-        // Run the test.
-        $cachedFetcher = new FetchAuthTokenCache(
-            $this->mockFetcher->reveal(),
-            null,
-            $this->mockCache->reveal()
-        );
-        $middleware = new AuthTokenMiddleware($cachedFetcher);
-        $mock = new MockHandler([new Response(200)]);
-        $callable = $middleware($mock);
-        $callable($this->mockRequest->reveal(), ['auth' => 'google_auth']);
-    }
-
-    public function testGetsCachedAuthTokenUsingCacheOptions()
-    {
-        $prefix = 'test_prefix_';
-        $cacheKey = 'myKey';
-        $cachedValue = '2/abcdef1234567890';
-        $this->mockCacheItem->isHit()
-            ->shouldBeCalledTimes(1)
-            ->willReturn(true);
-        $this->mockCacheItem->get()
-            ->shouldBeCalledTimes(1)
-            ->willReturn($cachedValue);
-        $this->mockCache->getItem($prefix . $cacheKey)
-            ->shouldBeCalledTimes(1)
-            ->willReturn($this->mockCacheItem->reveal());
-        $this->mockFetcher->fetchAuthToken()
-            ->shouldNotBeCalled();
-        $this->mockFetcher->getCacheKey()
-            ->shouldBeCalled()
-            ->willReturn($cacheKey);
-        $this->mockRequest->withHeader('authorization', 'Bearer ' . $cachedValue)
-            ->shouldBeCalledTimes(1)
-            ->willReturn($this->mockRequest->reveal());
-
-        // Run the test.
-        $cachedFetcher = new FetchAuthTokenCache(
-            $this->mockFetcher->reveal(),
-            ['prefix' => $prefix],
-            $this->mockCache->reveal()
-        );
-        $middleware = new AuthTokenMiddleware($cachedFetcher);
-        $mock = new MockHandler([new Response(200)]);
-        $callable = $middleware($mock);
-        $callable($this->mockRequest->reveal(), ['auth' => 'google_auth']);
-    }
-
-    public function testShouldSaveValueInCacheWithSpecifiedPrefix()
-    {
-        $prefix = 'test_prefix_';
-        $lifetime = '70707';
-        $cacheKey = 'myKey';
-        $token = '1/abcdef1234567890';
-        $authResult = ['access_token' => $token];
-        $this->mockCacheItem->get()
-            ->willReturn(null);
-        $this->mockCacheItem->isHit()
-            ->willReturn(false);
-        $this->mockCacheItem->set($token)
-            ->shouldBeCalledTimes(1)
-            ->willReturn(false);
-        $this->mockCacheItem->expiresAfter($lifetime)
-            ->shouldBeCalledTimes(1);
-        $this->mockCache->getItem($prefix . $cacheKey)
-            ->shouldBeCalled()
-            ->willReturn($this->mockCacheItem->reveal());
-        $this->mockCache->save(Argument::type('Psr\Cache\CacheItemInterface'))
-            ->shouldBeCalled();
-        $this->mockFetcher->getCacheKey()
-            ->shouldBeCalled()
-            ->willReturn($cacheKey);
-        $this->mockFetcher->fetchAuthToken(Argument::any())
-            ->shouldBeCalledTimes(1)
-            ->willReturn($authResult);
-        $this->mockRequest->withHeader('authorization', 'Bearer ' . $token)
-            ->shouldBeCalledTimes(1)
-            ->willReturn($this->mockRequest->reveal());
-
-        // Run the test.
-        $cachedFetcher = new FetchAuthTokenCache(
-            $this->mockFetcher->reveal(),
-            ['prefix' => $prefix, 'lifetime' => $lifetime],
-            $this->mockCache->reveal()
-        );
-        $middleware = new AuthTokenMiddleware($cachedFetcher);
-        $mock = new MockHandler([new Response(200)]);
-        $callable = $middleware($mock);
-        $callable($this->mockRequest->reveal(), ['auth' => 'google_auth']);
-    }
-
     /**
      * @dataProvider provideShouldNotifyTokenCallback
      */
     public function testShouldNotifyTokenCallback(callable $tokenCallback)
     {
-        $prefix = 'test_prefix_';
-        $cacheKey = 'myKey';
-        $token = '1/abcdef1234567890';
-        $authResult = ['access_token' => $token];
-        $this->mockCacheItem->get()
-            ->willReturn(null);
-        $this->mockCacheItem->isHit()
-            ->willReturn(false);
-        $this->mockCacheItem->set($token)
-            ->shouldBeCalled();
-        $this->mockCacheItem->expiresAfter(Argument::any())
-            ->shouldBeCalled();
-        $this->mockCache->getItem($prefix . $cacheKey)
-            ->willReturn($this->mockCacheItem->reveal());
-        $this->mockCache->save(Argument::type('Psr\Cache\CacheItemInterface'))
-            ->shouldBeCalled();
+        $wantCacheKey  = "cache-key";
+        $wantAuthToken = ['access_token' => "1/abcdef1234567890"];
+
         $this->mockFetcher->getCacheKey()
-            ->willReturn($cacheKey);
+            ->willReturn($wantCacheKey);
+
         $this->mockFetcher->fetchAuthToken(Argument::any())
-            ->shouldBeCalledTimes(1)
-            ->willReturn($authResult);
+            ->willReturn($wantAuthToken);
+
         $this->mockRequest->withHeader(Argument::any(), Argument::any())
             ->willReturn($this->mockRequest->reveal());
 
-        MiddlewareCallback::$expectedKey = $this->getValidKeyName($prefix . $cacheKey);
-        MiddlewareCallback::$expectedValue = $token;
-        MiddlewareCallback::$called = false;
+        MiddlewareCallback::$expectedKey   = $wantCacheKey;
+        MiddlewareCallback::$expectedValue = $wantAuthToken['access_token'];
+        MiddlewareCallback::$called        = false;
 
-        // Run the test.
-        $cachedFetcher = new FetchAuthTokenCache(
-            $this->mockFetcher->reveal(),
-            ['prefix' => $prefix],
-            $this->mockCache->reveal()
-        );
         $middleware = new AuthTokenMiddleware(
-            $cachedFetcher,
+            $this->mockFetcher->reveal(),
             null,
             $tokenCallback
         );
-        $mock = new MockHandler([new Response(200)]);
-        $callable = $middleware($mock);
+
+        $handler  = new MockHandler([new Response(200)]);
+        $callable = $middleware($handler);
+
         $callable($this->mockRequest->reveal(), ['auth' => 'google_auth']);
+
         $this->assertTrue(MiddlewareCallback::$called);
     }
 

--- a/tests/Middleware/ScopedAccessTokenMiddlewareTest.php
+++ b/tests/Middleware/ScopedAccessTokenMiddlewareTest.php
@@ -27,16 +27,14 @@ class ScopedAccessTokenMiddlewareTest extends BaseTest
 {
     const TEST_SCOPE = 'https://www.googleapis.com/auth/cloud-taskqueue';
 
-    private $mockCacheItem;
-    private $mockCache;
+    private $tokenFunc;
     private $mockRequest;
 
     protected function setUp()
     {
         $this->onlyGuzzle6And7();
 
-        $this->mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
-        $this->mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
+        $this->tokenFunc = new TokenFuncImplementation;
         $this->mockRequest = $this->prophesize('GuzzleHttp\Psr7\Request');
     }
 
@@ -45,177 +43,76 @@ class ScopedAccessTokenMiddlewareTest extends BaseTest
      */
     public function testRequiresScopeAsAStringOrArray()
     {
-        $fakeAuthFunc = function ($unused_scopes) {
-            return '1/abcdef1234567890';
-        };
-        new ScopedAccessTokenMiddleware($fakeAuthFunc, new \stdClass());
+        new ScopedAccessTokenMiddleware($this->tokenFunc, new \stdClass());
     }
 
     public function testAddsTheTokenAsAnAuthorizationHeader()
     {
-        $token = '1/abcdef1234567890';
-        $fakeAuthFunc = function ($unused_scopes) use ($token) {
-            return $token;
-        };
-        $this->mockRequest->withHeader('authorization', 'Bearer ' . $token)
+        $wantToken = $this->tokenFunc->value();
+
+        $this->mockRequest->withHeader('authorization', 'Bearer ' . $wantToken)
             ->shouldBeCalledTimes(1)
             ->willReturn($this->mockRequest->reveal());
 
         // Run the test
-        $middleware = new ScopedAccessTokenMiddleware($fakeAuthFunc, self::TEST_SCOPE);
+        $middleware = new ScopedAccessTokenMiddleware($this->tokenFunc, self::TEST_SCOPE);
         $mock = new MockHandler([new Response(200)]);
         $callable = $middleware($mock);
         $callable($this->mockRequest->reveal(), ['auth' => 'scoped']);
     }
 
-    public function testUsesCachedAuthToken()
+    public function testCachesToken()
     {
-        $cachedValue = '2/abcdef1234567890';
-        $fakeAuthFunc = function ($unused_scopes) {
-            return '';
-        };
-        $this->mockCacheItem->isHit()
-            ->shouldBeCalledTimes(1)
-            ->willReturn(true);
-        $this->mockCacheItem->get()
-            ->shouldBeCalledTimes(1)
-            ->willReturn($cachedValue);
-        $this->mockCache->getItem($this->getValidKeyName(self::TEST_SCOPE))
-            ->shouldBeCalledTimes(1)
-            ->willReturn($this->mockCacheItem->reveal());
-        $this->mockRequest->withHeader('authorization', 'Bearer ' . $cachedValue)
-            ->shouldBeCalledTimes(1)
-            ->willReturn($this->mockRequest->reveal());
+        $wantToken = $this->tokenFunc->value();
 
-        // Run the test
-        $middleware = new ScopedAccessTokenMiddleware(
-            $fakeAuthFunc,
-            self::TEST_SCOPE,
-            [],
-            $this->mockCache->reveal()
-        );
-        $mock = new MockHandler([new Response(200)]);
-        $callable = $middleware($mock);
-        $callable($this->mockRequest->reveal(), ['auth' => 'scoped']);
-    }
-
-    public function testGetsCachedAuthTokenUsingCachePrefix()
-    {
-        $prefix = 'test_prefix_';
-        $cachedValue = '2/abcdef1234567890';
-        $fakeAuthFunc = function ($unused_scopes) {
-            return '';
-        };
-        $this->mockCacheItem->isHit()
-            ->shouldBeCalledTimes(1)
-            ->willReturn(true);
-        $this->mockCacheItem->get()
-            ->shouldBeCalledTimes(1)
-            ->willReturn($cachedValue);
-        $this->mockCache->getItem($prefix . $this->getValidKeyName(self::TEST_SCOPE))
-            ->shouldBeCalledTimes(1)
-            ->willReturn($this->mockCacheItem->reveal());
-        $this->mockRequest->withHeader('authorization', 'Bearer ' . $cachedValue)
-            ->shouldBeCalledTimes(1)
-            ->willReturn($this->mockRequest->reveal());
-
-        // Run the test
-        $middleware = new ScopedAccessTokenMiddleware(
-            $fakeAuthFunc,
-            self::TEST_SCOPE,
-            ['prefix' => $prefix],
-            $this->mockCache->reveal()
-        );
-        $mock = new MockHandler([new Response(200)]);
-        $callable = $middleware($mock);
-        $callable($this->mockRequest->reveal(), ['auth' => 'scoped']);
-    }
-
-    public function testShouldSaveValueInCache()
-    {
-        $token = '2/abcdef1234567890';
-        $fakeAuthFunc = function ($unused_scopes) use ($token) {
-            return $token;
-        };
-        $this->mockCacheItem->isHit()
-            ->shouldBeCalledTimes(1)
-            ->willReturn(false);
-        $this->mockCacheItem->set($token)
-            ->shouldBeCalledTimes(1)
-            ->willReturn(false);
-        $this->mockCacheItem->expiresAfter(Argument::any())
-            ->shouldBeCalledTimes(1);
-        $this->mockCache->getItem($this->getValidKeyName(self::TEST_SCOPE))
+        $this->mockRequest->withHeader('authorization', 'Bearer ' . $wantToken)
             ->shouldBeCalledTimes(2)
-            ->willReturn($this->mockCacheItem->reveal());
-        $this->mockCache->save(Argument::type('Psr\Cache\CacheItemInterface'))
-            ->shouldBeCalled()
-            ->willReturn(true);
-        $this->mockRequest->withHeader('authorization', 'Bearer ' . $token)
-            ->shouldBeCalledTimes(1)
             ->willReturn($this->mockRequest->reveal());
 
         // Run the test
         $middleware = new ScopedAccessTokenMiddleware(
-            $fakeAuthFunc,
+            $this->tokenFunc,
             self::TEST_SCOPE,
-            [],
-            $this->mockCache->reveal()
         );
-        $mock = new MockHandler([new Response(200)]);
-        $callable = $middleware($mock);
-        $callable($this->mockRequest->reveal(), ['auth' => 'scoped']);
-    }
 
-    public function testShouldSaveValueInCacheWithCacheOptions()
-    {
-        $token = '2/abcdef1234567890';
-        $prefix = 'test_prefix_';
-        $lifetime = '70707';
-        $fakeAuthFunc = function ($unused_scopes) use ($token) {
-            return $token;
-        };
-        $this->mockCacheItem->isHit()
-            ->shouldBeCalledTimes(1)
-            ->willReturn(false);
-        $this->mockCacheItem->set($token)
-            ->shouldBeCalledTimes(1)
-            ->willReturn(false);
-        $this->mockCacheItem->expiresAfter($lifetime)
-            ->shouldBeCalledTimes(1);
-        $this->mockCache->getItem($prefix . $this->getValidKeyName(self::TEST_SCOPE))
-            ->shouldBeCalledTimes(2)
-            ->willReturn($this->mockCacheItem->reveal());
-        $this->mockCache->save(Argument::type('Psr\Cache\CacheItemInterface'))
-            ->shouldBeCalled()
-            ->willReturn(true);
-        $this->mockRequest->withHeader('authorization', 'Bearer ' . $token)
-            ->shouldBeCalledTimes(1)
-            ->willReturn($this->mockRequest->reveal());
+        $request  = $this->mockRequest->reveal();
+        $handler  = new MockHandler([new Response(200), new Response(200)]);
+        $callable = $middleware($handler);
 
-        // Run the test
-        $middleware = new ScopedAccessTokenMiddleware(
-            $fakeAuthFunc,
-            self::TEST_SCOPE,
-            ['prefix' => $prefix, 'lifetime' => $lifetime],
-            $this->mockCache->reveal()
-        );
-        $mock = new MockHandler([new Response(200)]);
-        $callable = $middleware($mock);
-        $callable($this->mockRequest->reveal(), ['auth' => 'scoped']);
+        $callable($request, ['auth' => 'scoped']);
+        $callable($request, ['auth' => 'scoped']);
     }
 
     public function testOnlyTouchesWhenAuthConfigScoped()
     {
-        $fakeAuthFunc = function ($unused_scopes) {
-            return '1/abcdef1234567890';
-        };
         $this->mockRequest->withHeader()->shouldNotBeCalled();
 
         // Run the test
-        $middleware = new ScopedAccessTokenMiddleware($fakeAuthFunc, self::TEST_SCOPE);
+        $middleware = new ScopedAccessTokenMiddleware($this->tokenFunc, self::TEST_SCOPE);
         $mock = new MockHandler([new Response(200)]);
         $callable = $middleware($mock);
         $callable($this->mockRequest->reveal(), ['auth' => 'not_scoped']);
+    }
+}
+
+class TokenFuncImplementation
+{
+    private $iteration;
+
+    public function __construct($iteration = 0)
+    {
+        $this->iteration = $iteration;
+    }
+
+    public function __invoke($unused_scopes) {
+        $value = $this->value();
+
+        $this->iteration++;
+
+        return $value;
+    }
+
+    public function value() {
+        return "auth-token-{$this->iteration}";
     }
 }


### PR DESCRIPTION
This PR makes changes to the `CacheTrait` trait in order to add the ability to enable per-item expiration dates, and updates the `FetchAuthTokenCache` class in order to specify the auth token expiry when caching.

At the time of this pull request, there is a > 4 year old TODO in the `FetchAuthTokenCache` class:

https://github.com/googleapis/google-auth-library-php/blob/077d6ae98d550161d3b2a0ba283bdce785c74d85/src/FetchAuthTokenCache.php#L81-L84

Unfortunately this means that code using this library is subject to a potential error condition in which the auth token is cached for longer than it is valid. While the library does set a maximum lifetime of 1500 seconds (25 minutes) for tokens, it is possible for a Google metadata server to return an access token that expires within that lifetime; any API calls made using this token during that time frame will fail with a `403 Permission Denied` error.

From experience this bug has lead to more than one brief outage of a service that utilizes the cached tokens, and the goal of this PR is to eliminate the issue.

Note to maintainers:

* It may be helpful to go through the PR one commit at a time.
* I am under the impression that you strive to maintain a compatible public API, I consider the `CacheTrait` internal to the library and felt comfortable making breaking changes here, let me know if this is not the case.
* I'm fairly certain tests in `tests/Subscriber` will fail, I did not include updates to them as I wanted to get feedback on the general idea of the PR first.
* I've removed a decent number tests that I consider redudant - the `AuthTokenMiddlewareTest`, for example, includes tests that depend on the cache although the `AuthTokenMiddleware` class itself doesn't care whether or not it is using a caching `FetchAuthTokenInterface`. If there are any you disagree with, I'm happy to discuss and re-include them.

Thanks!