### PR TITLE
fix: catch ConnectException in GCE check

### DIFF
--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -25,6 +25,7 @@ use Google\Auth\Iam;
 use Google\Auth\ProjectIdProviderInterface;
 use Google\Auth\SignBlobInterface;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
@@ -283,6 +284,7 @@ class GCECredentials extends CredentialsLoader implements
             } catch (ClientException $e) {
             } catch (ServerException $e) {
             } catch (RequestException $e) {
+            } catch (ConnectException $e) {
             }
         }
         return false;


### PR DESCRIPTION
Guzzle 7 [separated `ConnectException` from `RequestException`](https://github.com/guzzle/guzzle/pull/2541). When we ping the GCE metadata server, if we aren't on GCE, we'll get a `ConnectException`, which, since it's no longer caught, will bubble up to the user.