### PR TITLE
feat: adds caching for call to ::onGce

### DIFF
--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -172,7 +172,7 @@ class ApplicationDefaultCredentials
             $creds = CredentialsLoader::makeCredentials($scope, $jsonKey);
         } elseif (AppIdentityCredentials::onAppEngine() && !GCECredentials::onAppEngineFlexible()) {
             $creds = new AppIdentityCredentials($scope);
-        } elseif (GCECredentials::onGce($httpHandler)) {
+        } elseif ((new GCECache($cacheConfig, $cache))->onGce($httpHandler)) {
             $creds = new GCECredentials(null, $scope, null, $quotaProject);
         }
 
@@ -259,7 +259,7 @@ class ApplicationDefaultCredentials
             }
 
             $creds = new ServiceAccountCredentials(null, $jsonKey, null, $targetAudience);
-        } elseif (GCECredentials::onGce($httpHandler)) {
+        } elseif ((new GCECache($cache, $cacheConfig))->onGce($httpHandler)) {
             $creds = new GCECredentials(null, null, $targetAudience);
         }
 

--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -172,7 +172,7 @@ class ApplicationDefaultCredentials
             $creds = CredentialsLoader::makeCredentials($scope, $jsonKey);
         } elseif (AppIdentityCredentials::onAppEngine() && !GCECredentials::onAppEngineFlexible()) {
             $creds = new AppIdentityCredentials($scope);
-        } elseif ((new GCECache($cacheConfig, $cache))->onGce($httpHandler)) {
+        } elseif (self::onGce($httpHandler, $cacheConfig, $cache)) {
             $creds = new GCECredentials(null, $scope, null, $quotaProject);
         }
 
@@ -259,7 +259,7 @@ class ApplicationDefaultCredentials
             }
 
             $creds = new ServiceAccountCredentials(null, $jsonKey, null, $targetAudience);
-        } elseif ((new GCECache($cache, $cacheConfig))->onGce($httpHandler)) {
+        } elseif (self::onGce($httpHandler, $cacheConfig, $cache)) {
             $creds = new GCECredentials(null, null, $targetAudience);
         }
 
@@ -280,5 +280,20 @@ class ApplicationDefaultCredentials
         $msg .= ' for more information';
 
         return $msg;
+    }
+
+    private static function onGce(
+        callable $httpHandler = null,
+        array $cacheConfig = null,
+        CacheItemPoolInterface $cache = null
+    ) {
+        $gceCacheConfig = [];
+        foreach (['lifetime', 'prefix'] as $key) {
+            if (isset($cacheConfig['gce_' . $key])) {
+                $gceCacheConfig[$key] = $cacheConfig['gce_' . $key];
+            }
+        }
+
+        return (new GCECache($gceCacheConfig, $cache))->onGce($httpHandler);
     }
 }

--- a/src/GCECache.php
+++ b/src/GCECache.php
@@ -52,7 +52,6 @@ class GCECache
         $this->cacheConfig = array_merge([
             'lifetime' => 1500,
             'prefix' => '',
-            'key' => self::GCE_CACHE_KEY,
         ], (array) $cacheConfig);
     }
 
@@ -69,7 +68,7 @@ class GCECache
             return GCECredentials::onGce($httpHandler);
         }
 
-        $cacheKey = $this->cacheConfig['key'];
+        $cacheKey = self::GCE_CACHE_KEY;
         $onGce = $this->getCachedValue($cacheKey);
 
         if (is_null($onGce)) {

--- a/src/GCECache.php
+++ b/src/GCECache.php
@@ -21,8 +21,19 @@ use Google\Auth\Credentials\GCECredentials;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
- * A class to implement caching for any object implementing
- * FetchAuthTokenInterface
+ * A class to implement caching for calls to GCECredentials::onGce. This class
+ * is used automatically when you pass a `Psr\Cache\CacheItemPoolInterface`
+ * cache object to `ApplicationDefaultCredentials::getCredentials`.
+ *
+ * ```
+ * $sysvCache = new Google\Auth\SysvCacheItemPool();
+ * $creds = Google\Auth\ApplicationDefaultCredentials::getCredentials(
+ *     $scope,
+ *     null,
+ *     null,
+ *     $sysvCache
+ * );
+ * ```
  */
 class GCECache
 {

--- a/src/GCECache.php
+++ b/src/GCECache.php
@@ -1,0 +1,82 @@
+<?php
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth;
+
+use Google\Auth\Credentials\GCECredentials;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * A class to implement caching for any object implementing
+ * FetchAuthTokenInterface
+ */
+class GCECache
+{
+    const GCE_CACHE_KEY = 'google_auth_on_gce_cache';
+
+    use CacheTrait;
+
+    /**
+     * @var array
+     */
+    private $cacheConfig;
+
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    /**
+     * @param array $cacheConfig Configuration for the cache
+     * @param CacheItemPoolInterface $cache
+     */
+    public function __construct(
+        array $cacheConfig = null,
+        CacheItemPoolInterface $cache = null
+    ) {
+        $this->cache = $cache;
+        $this->cacheConfig = array_merge([
+            'lifetime' => 1500,
+            'prefix' => '',
+            'key' => self::GCE_CACHE_KEY,
+        ], (array) $cacheConfig);
+    }
+
+    /**
+     * Caches the result of onGce so the metadata server is not called multiple
+     * times.
+     *
+     * @param callable $httpHandler callback which delivers psr7 request
+     * @return bool True if this a GCEInstance, false otherwise
+     */
+    public function onGce(callable $httpHandler = null)
+    {
+        if (is_null($this->cache)) {
+            return GCECredentials::onGce($httpHandler);
+        }
+
+        $cacheKey = $this->cacheConfig['key'];
+        $onGce = $this->getCachedValue($cacheKey);
+
+        if (is_null($onGce)) {
+            $onGce = GCECredentials::onGce($httpHandler);
+            $this->setCachedValue($cacheKey, $onGce);
+        }
+
+        return $onGce;
+    }
+}

--- a/tests/GCECacheTest.php
+++ b/tests/GCECacheTest.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Auth\Tests;
+
+use Google\Auth\Credentials\GCECredentials;
+use Google\Auth\GCECache;
+use GuzzleHttp\Psr7;
+use Prophecy\Argument;
+
+class GCECacheTest extends BaseTest
+{
+    private $mockCacheItem;
+    private $mockCache;
+
+    protected function setUp()
+    {
+        $this->mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
+        $this->mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
+    }
+
+    public function testCachedOnGceTrueValue()
+    {
+        $cachedValue = true;
+        $this->mockCacheItem->isHit()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(true);
+        $this->mockCacheItem->get()
+            ->shouldBeCalledTimes(1)
+            ->willReturn($cachedValue);
+        $this->mockCache->getItem(GCECache::GCE_CACHE_KEY)
+            ->shouldBeCalledTimes(1)
+            ->willReturn($this->mockCacheItem->reveal());
+
+        // Run the test.
+        $gceCache = new GCECache(
+            null,
+            $this->mockCache->reveal()
+        );
+        $this->assertTrue($gceCache->onGce());
+    }
+
+    public function testCachedOnGceFalseValue()
+    {
+        $cachedValue = false;
+        $this->mockCacheItem->isHit()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(true);
+        $this->mockCacheItem->get()
+            ->shouldBeCalledTimes(1)
+            ->willReturn($cachedValue);
+        $this->mockCache->getItem(GCECache::GCE_CACHE_KEY)
+            ->shouldBeCalledTimes(1)
+            ->willReturn($this->mockCacheItem->reveal());
+
+        // Run the test.
+        $gceCache = new GCECache(
+            null,
+            $this->mockCache->reveal()
+        );
+        $this->assertFalse($gceCache->onGce());
+    }
+
+    public function testUncached()
+    {
+        $gceIsCalled = false;
+        $dummyHandler = function ($request) use (&$gceIsCalled) {
+            $gceIsCalled = true;
+            return new Psr7\Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']);
+        };
+
+        $this->mockCacheItem->isHit()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(false);
+        $this->mockCacheItem->set(true)
+            ->shouldBeCalledTimes(1);
+        $this->mockCacheItem->expiresAfter(1500)
+            ->shouldBeCalledTimes(1);
+        $this->mockCache->getItem(GCECache::GCE_CACHE_KEY)
+            ->shouldBeCalledTimes(2)
+            ->willReturn($this->mockCacheItem->reveal());
+        $this->mockCache->save($this->mockCacheItem->reveal())
+            ->shouldBeCalledTimes(1);
+
+        // Run the test.
+        $gceCache = new GCECache(
+            null,
+            $this->mockCache->reveal()
+        );
+
+        $this->assertTrue($gceCache->onGce($dummyHandler));
+        $this->assertTrue($gceIsCalled);
+    }
+
+    public function testShouldFetchFromCacheWithCacheOptions()
+    {
+        $prefix = 'test_prefix_';
+        $lifetime = '70707';
+        $cachedValue = true;
+
+        $this->mockCacheItem->isHit()
+            ->willReturn(true);
+        $this->mockCacheItem->get()
+            ->willReturn($cachedValue);
+        $this->mockCache->getItem($prefix . GCECache::GCE_CACHE_KEY)
+            ->shouldBeCalledTimes(1)
+            ->willReturn($this->mockCacheItem->reveal());
+
+        // Run the test
+        $gceCache = new GCECache(
+            ['prefix' => $prefix, 'lifetime' => $lifetime],
+            $this->mockCache->reveal()
+        );
+        $this->assertTrue($gceCache->onGce());
+    }
+
+    public function testShouldSaveValueInCacheWithCacheOptions()
+    {
+        $prefix = 'test_prefix_';
+        $lifetime = '70707';
+        $gceIsCalled = false;
+        $dummyHandler = function ($request) use (&$gceIsCalled) {
+            $gceIsCalled = true;
+            return new Psr7\Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']);
+        };
+        $this->mockCacheItem->isHit()
+            ->willReturn(false);
+        $this->mockCacheItem->set(true)
+            ->shouldBeCalledTimes(1);
+        $this->mockCacheItem->expiresAfter($lifetime)
+            ->shouldBeCalledTimes(1);
+        $this->mockCache->getItem($prefix . GCECache::GCE_CACHE_KEY)
+            ->shouldBeCalledTimes(2)
+            ->willReturn($this->mockCacheItem->reveal());
+        $this->mockCache->save($this->mockCacheItem->reveal())
+            ->shouldBeCalled();
+
+        // Run the test
+        $gceCache = new GCECache(
+            ['prefix' => $prefix, 'lifetime' => $lifetime],
+            $this->mockCache->reveal()
+        );
+        $onGce = $gceCache->onGce($dummyHandler);
+        $this->assertTrue($onGce);
+        $this->assertTrue($gceIsCalled);
+    }
+}


### PR DESCRIPTION
Addresses #297 

 - New class `GCECache`
 - `ApplicationDefaultCredentials` automatically caches `onGce` response using the same `$cacheOptions` and `$cache` passed into `getCredentials` and `getIdTokenCredentials`
 - `$cacheOptions` are the same for `GCECache` and `FetchAuthTokenCache`. Is this ok?
 - `key` option allows flexibility for cache key, which defaults to `google_auth_on_gce_cache` (do we need this?)

The biggest issue I see is not being able to set a different lifetime/prefix between GCE and Access Token caches. To address this, `ApplicationDefaultCredentials` could create a new `$cacheOptions` for `GCECache` and allow for keys like `gce_lifetime` and `gce_prefix`

```php
$cacheOptions = [
    'lifetime' => 1500,
    'prefix' => 'access_token_',
    'gce_lifetime' => 3000,
    'gce_prefix' => 'on_gce_',
];
$creds = ApplicationDefaultCredentials::getCredentials(null, null, $cacheOptions, $cache);
```