### PR TITLE
feat: add service account identity support to GCECredentials

### DIFF
--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -160,15 +160,27 @@ class GCECredentials extends CredentialsLoader implements
     private $quotaProject;
 
     /**
+     * @var string|null
+     */
+    private $serviceAccountIdentity;
+
+    /**
      * @param Iam $iam [optional] An IAM instance.
      * @param string|array $scope [optional] the scope of the access request,
      *        expressed either as an array or as a space-delimited string.
      * @param string $targetAudience [optional] The audience for the ID token.
      * @param string $quotaProject [optional] Specifies a project to bill for access
      *   charges associated with the request.
+     * @param string $serviceAccountIdentity [optional] Specify a service
+     *   account identity name to use instead of "default".
      */
-    public function __construct(Iam $iam = null, $scope = null, $targetAudience = null, $quotaProject = null)
-    {
+    public function __construct(
+        Iam $iam = null,
+        $scope = null,
+        $targetAudience = null,
+        $quotaProject = null,
+        $serviceAccountIdentity = null
+    ) {
         $this->iam = $iam;
 
         if ($scope && $targetAudience) {
@@ -177,7 +189,7 @@ class GCECredentials extends CredentialsLoader implements
             );
         }
 
-        $tokenUri = self::getTokenUri();
+        $tokenUri = self::getTokenUri($serviceAccountIdentity);
         if ($scope) {
             if (is_string($scope)) {
                 $scope = explode(' ', $scope);
@@ -187,41 +199,82 @@ class GCECredentials extends CredentialsLoader implements
 
             $tokenUri = $tokenUri . '?scopes='. $scope;
         } elseif ($targetAudience) {
-            $tokenUri = sprintf(
-                'http://%s/computeMetadata/%s?audience=%s',
-                self::METADATA_IP,
-                self::ID_TOKEN_URI_PATH,
-                $targetAudience
-            );
+            $tokenUri = self::getIdTokenUri($serviceAccountIdentity);
+            $tokenUri = $tokenUri . '?audience='. $targetAudience;
             $this->targetAudience = $targetAudience;
         }
 
         $this->tokenUri = $tokenUri;
         $this->quotaProject = $quotaProject;
+        $this->serviceAccountIdentity = $serviceAccountIdentity;
     }
 
     /**
      * The full uri for accessing the default token.
      *
+     * @param string $serviceAccountIdentity [optional] Specify a service
+     *   account identity name to use instead of "default".
      * @return string
      */
-    public static function getTokenUri()
+    public static function getTokenUri(string $serviceAccountIdentity = null)
     {
         $base = 'http://' . self::METADATA_IP . '/computeMetadata/';
+        $base .= self::TOKEN_URI_PATH;
 
-        return $base . self::TOKEN_URI_PATH;
+        if ($serviceAccountIdentity) {
+            return str_replace(
+                '/default/',
+                '/' . $serviceAccountIdentity . '/',
+                $base
+            );
+        }
+        return $base;
     }
 
     /**
      * The full uri for accessing the default service account.
      *
+     * @param string $serviceAccountIdentity [optional] Specify a service
+     *   account identity name to use instead of "default".
      * @return string
      */
-    public static function getClientNameUri()
+    public static function getClientNameUri(string $serviceAccountIdentity = null)
     {
         $base = 'http://' . self::METADATA_IP . '/computeMetadata/';
+        $base .= self::CLIENT_ID_URI_PATH;
 
-        return $base . self::CLIENT_ID_URI_PATH;
+        if ($serviceAccountIdentity) {
+            return str_replace(
+                '/default/',
+                '/' . $serviceAccountIdentity . '/',
+                $base
+            );
+        }
+
+        return $base;
+    }
+
+    /**
+     * The full uri for accesesing the default identity token.
+     *
+     * @param string $serviceAccountIdentity [optional] Specify a service
+     *   account identity name to use instead of "default".
+     * @return string
+     */
+    private static function getIdTokenUri(string $serviceAccountIdentity = null)
+    {
+        $base = 'http://' . self::METADATA_IP . '/computeMetadata/';
+        $base .= self::ID_TOKEN_URI_PATH;
+
+        if ($serviceAccountIdentity) {
+            return str_replace(
+                '/default/',
+                '/' . $serviceAccountIdentity . '/',
+                $base
+            );
+        }
+
+        return $base;
     }
 
     /**
@@ -388,7 +441,10 @@ class GCECredentials extends CredentialsLoader implements
             return '';
         }
 
-        $this->clientName = $this->getFromMetadata($httpHandler, self::getClientNameUri());
+        $this->clientName = $this->getFromMetadata(
+            $httpHandler,
+            self::getClientNameUri($this->serviceAccountIdentity)
+        );
 
         return $this->clientName;
     }

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -216,7 +216,7 @@ class GCECredentials extends CredentialsLoader implements
      *   account identity name to use instead of "default".
      * @return string
      */
-    public static function getTokenUri(string $serviceAccountIdentity = null)
+    public static function getTokenUri($serviceAccountIdentity = null)
     {
         $base = 'http://' . self::METADATA_IP . '/computeMetadata/';
         $base .= self::TOKEN_URI_PATH;
@@ -238,7 +238,7 @@ class GCECredentials extends CredentialsLoader implements
      *   account identity name to use instead of "default".
      * @return string
      */
-    public static function getClientNameUri(string $serviceAccountIdentity = null)
+    public static function getClientNameUri($serviceAccountIdentity = null)
     {
         $base = 'http://' . self::METADATA_IP . '/computeMetadata/';
         $base .= self::CLIENT_ID_URI_PATH;
@@ -261,7 +261,7 @@ class GCECredentials extends CredentialsLoader implements
      *   account identity name to use instead of "default".
      * @return string
      */
-    private static function getIdTokenUri(string $serviceAccountIdentity = null)
+    private static function getIdTokenUri($serviceAccountIdentity = null)
     {
         $base = 'http://' . self::METADATA_IP . '/computeMetadata/';
         $base .= self::ID_TOKEN_URI_PATH;

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -403,7 +403,7 @@ class GCECredentialsTest extends BaseTest
                 buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google'])
             );
         $client->send($request, Argument::any())
-            ->shouldBeCalledOnce()
+            ->shouldBeCalled()
             ->willReturn(
                 buildResponse(200, [], Psr7\stream_for(json_encode($expected)))
             );
@@ -435,7 +435,7 @@ class GCECredentialsTest extends BaseTest
                 buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google'])
             );
         $client->send($request, Argument::any())
-            ->shouldBeCalledOnce()
+            ->shouldBeCalled()
             ->willReturn(buildResponse(200, [], Psr7\stream_for($expected)));
 
         $g = new GCECredentials(null, null, 'a+target+audience', null, 'foo');
@@ -472,7 +472,7 @@ class GCECredentialsTest extends BaseTest
                 buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google'])
             );
         $client->send($request, Argument::any())
-            ->shouldBeCalledOnce()
+            ->shouldBeCalled()
             ->willReturn(buildResponse(200, [], Psr7\stream_for($expected)));
 
         $creds = new GCECredentials(null, null, null, null, 'foo');

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -19,7 +19,6 @@ namespace Google\Auth\Tests\Credentials;
 
 use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\HttpHandler\HttpClientCache;
-use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Auth\Tests\BaseTest;
 use GuzzleHttp\Psr7;
 use Prophecy\Argument;


### PR DESCRIPTION
Adds the ability to change from using the `default` service account in `GCECredentials`

See #303