### PR TITLE
fix: ensure cached tokens are used for GCECredentials::signBlob

### DIFF
--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -460,9 +460,12 @@ class GCECredentials extends CredentialsLoader implements
      * @param string $stringToSign The string to sign.
      * @param bool $forceOpenSsl [optional] Does not apply to this credentials
      *        type.
+     * @param string $accessToken The access token to use to sign the blob. If
+     *        provided, saves a call to the metadata server for a new access
+     *        token. **Defaults to** `null`.
      * @return string
      */
-    public function signBlob($stringToSign, $forceOpenSsl = false)
+    public function signBlob($stringToSign, $forceOpenSsl = false, $accessToken = null)
     {
         $httpHandler = HttpHandlerFactory::build(HttpClientCache::getHttpClient());
 
@@ -472,10 +475,12 @@ class GCECredentials extends CredentialsLoader implements
 
         $email = $this->getClientName($httpHandler);
 
-        $previousToken = $this->getLastReceivedToken();
-        $accessToken = $previousToken
-            ? $previousToken['access_token']
-            : $this->fetchAuthToken($httpHandler)['access_token'];
+        if (is_null($accessToken)) {
+            $previousToken = $this->getLastReceivedToken();
+            $accessToken = $previousToken
+                ? $previousToken['access_token']
+                : $this->fetchAuthToken($httpHandler)['access_token'];
+        }
 
         return $signer->signBlob($email, $accessToken, $stringToSign);
     }

--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -142,6 +142,13 @@ class FetchAuthTokenCache implements
             );
         }
 
+        // Fetch access token from cache for signing a blob
+        if ($this->fetcher instanceof Credentials\GCECredentials) {
+            $cached = $this->fetchAuthTokenFromCache();
+            $accessToken = isset($cached['access_token']) ? $cached['access_token'] : null;
+            return $this->fetcher->signBlob($stringToSign, $forceOpenSsl, $accessToken);
+        }
+
         return $this->fetcher->signBlob($stringToSign, $forceOpenSsl);
     }
 

--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -142,7 +142,8 @@ class FetchAuthTokenCache implements
             );
         }
 
-        // Fetch access token from cache for signing a blob
+        // Pass the access token from cache to GCECredentials for signing a blob.
+        // This saves a call to the metadata server when a cached token exists.
         if ($this->fetcher instanceof Credentials\GCECredentials) {
             $cached = $this->fetchAuthTokenFromCache();
             $accessToken = isset($cached['access_token']) ? $cached['access_token'] : null;


### PR DESCRIPTION
fixes https://github.com/googleapis/google-auth-library-php/issues/328

@Babacooll PTAL