### PR TITLE
feat: Adding support for guzzlehttp/psr7:^2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.17.1 (08/25/2021)
-
-* [chore]: Replaced the use of deprecated functions in Guzzlehttp/Psr7 and bumbed the version from **^1.2** to **^1.7|^2.0**
-
 ## 1.17.0 (08/17/2021)
 
  * [fix]: consistently use useSelfSignedJwt method in ServiceAccountJwtAccessCredentials (#351)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.1 (08/25/2021)
+
+* [chore]: Replaced the use of deprecated functions in Guzzlehttp/Psr7 and bumbed the version from **^1.2** to **^1.7|^2.0**
+
 ## 1.17.0 (08/17/2021)
 
  * [fix]: consistently use useSelfSignedJwt method in ServiceAccountJwtAccessCredentials (#351)

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=5.4",
     "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",
     "guzzlehttp/guzzle": "^5.3.1|^6.2.1|^7.0",
-    "guzzlehttp/psr7": "^1.2",
+    "guzzlehttp/psr7": "^1.7|^2.0",
     "psr/http-message": "^1.0",
     "psr/cache": "^1.0|^2.0"
   },

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -25,8 +25,8 @@ use Firebase\JWT\SignatureInvalidException;
 use Google\Auth\Cache\MemoryCacheItemPool;
 use Google\Auth\HttpHandler\HttpClientCache;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
 use InvalidArgumentException;
 use phpseclib\Crypt\RSA;
 use phpseclib\Math\BigInteger;
@@ -300,7 +300,7 @@ class AccessToken
             }
         }
 
-        $body = Psr7\stream_for(http_build_query(['token' => $token]));
+        $body = Utils::streamFor(http_build_query(['token' => $token]));
         $request = new Request('POST', self::OAUTH2_REVOKE_URI, [
             'Cache-Control' => 'no-store',
             'Content-Type'  => 'application/x-www-form-urlencoded',

--- a/src/Iam.php
+++ b/src/Iam.php
@@ -20,6 +20,7 @@ namespace Google\Auth;
 use Google\Auth\HttpHandler\HttpClientCache;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 
 /**
  * Tools for using the IAM API.
@@ -88,7 +89,7 @@ class Iam
             'POST',
             $uri,
             $headers,
-            Psr7\stream_for(json_encode($body))
+            Utils::streamFor(json_encode($body))
         );
 
         $res = $httpHandler($request);

--- a/src/Middleware/SimpleMiddleware.php
+++ b/src/Middleware/SimpleMiddleware.php
@@ -17,7 +17,7 @@
 
 namespace Google\Auth\Middleware;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Query;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -81,9 +81,9 @@ class SimpleMiddleware
                 return $handler($request, $options);
             }
 
-            $query = Psr7\parse_query($request->getUri()->getQuery());
+            $query = Query::parse($request->getUri()->getQuery());
             $params = array_merge($query, $this->config);
-            $uri = $request->getUri()->withQuery(Psr7\build_query($params));
+            $uri = $request->getUri()->withQuery(Query::build($params));
             $request = $request->withUri($uri);
 
             return $handler($request, $options);

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -19,8 +19,9 @@ namespace Google\Auth;
 
 use Google\Auth\HttpHandler\HttpClientCache;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
 use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -515,7 +516,7 @@ class OAuth2 implements FetchAuthTokenInterface
             'POST',
             $uri,
             $headers,
-            Psr7\build_query($params)
+            Query::build($params)
         );
     }
 
@@ -690,10 +691,10 @@ class OAuth2 implements FetchAuthTokenInterface
 
         // Construct the uri object; return it if it is valid.
         $result = clone $this->authorizationUri;
-        $existingParams = Psr7\parse_query($result->getQuery());
+        $existingParams = Query::parse($result->getQuery());
 
         $result = $result->withQuery(
-            Psr7\build_query(array_merge($existingParams, $params))
+            Query::build(array_merge($existingParams, $params))
         );
 
         if ($result->getScheme() != 'https') {
@@ -1369,7 +1370,7 @@ class OAuth2 implements FetchAuthTokenInterface
             return;
         }
 
-        return Psr7\uri_for($uri);
+        return Utils::uriFor($uri);
     }
 
     /**

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -22,6 +22,7 @@ use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Auth\GCECache;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -99,7 +100,7 @@ class ADCGetTest extends TestCase
         // simulate the response from GCE.
         $httpHandler = getHandler([
             buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-            buildResponse(200, [], Psr7\stream_for($jsonTokens)),
+            buildResponse(200, [], Utils::streamFor($jsonTokens)),
         ]);
 
         $this->assertInstanceOf(
@@ -122,7 +123,7 @@ class ADCDefaultScopeTest extends TestCase
             null, // $scope
             $httpHandler = getHandler([
                 buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-                buildResponse(200, [], Psr7\stream_for($jsonTokens)),
+                buildResponse(200, [], Utils::streamFor($jsonTokens)),
             ]), // $httpHandler
             null, // $cacheConfig
             null, // $cache
@@ -146,7 +147,7 @@ class ADCDefaultScopeTest extends TestCase
             'a+user+scope', // $scope
             getHandler([
                 buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-                buildResponse(200, [], Psr7\stream_for($jsonTokens)),
+                buildResponse(200, [], Utils::streamFor($jsonTokens)),
             ]), // $httpHandler
             null, // $cacheConfig
             null, // $cache
@@ -351,7 +352,7 @@ class ADCGetMiddlewareTest extends TestCase
         // simulate the response from GCE.
         $httpHandler = getHandler([
             buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-            buildResponse(200, [], Psr7\stream_for($jsonTokens)),
+            buildResponse(200, [], Utils::streamFor($jsonTokens)),
         ]);
 
         $this->assertNotNull(ApplicationDefaultCredentials::getMiddleware('a scope', $httpHandler));
@@ -552,7 +553,7 @@ class ADCGetCredentialsWithTargetAudienceTest extends TestCase
         // simulate the response from GCE.
         $httpHandler = getHandler([
             buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-            buildResponse(200, [], Psr7\stream_for($jsonTokens)),
+            buildResponse(200, [], Utils::streamFor($jsonTokens)),
         ]);
 
         $credentials = ApplicationDefaultCredentials::getIdTokenCredentials(
@@ -663,7 +664,7 @@ class ADCGetCredentialsWithQuotaProjectTest extends TestCase
         // simulate the response from GCE.
         $httpHandler = getHandler([
             buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-            buildResponse(200, [], Psr7\stream_for($jsonTokens)),
+            buildResponse(200, [], Utils::streamFor($jsonTokens)),
         ]);
 
         $credentials = ApplicationDefaultCredentials::getCredentials(
@@ -850,7 +851,7 @@ class ADCGetSubscriberTest extends BaseTest
         // simulate the response from GCE.
         $httpHandler = getHandler([
             buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-            buildResponse(200, [], Psr7\stream_for($jsonTokens)),
+            buildResponse(200, [], Utils::streamFor($jsonTokens)),
         ]);
 
         $this->assertNotNull(ApplicationDefaultCredentials::getSubscriber('a scope', $httpHandler));

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -21,6 +21,7 @@ use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\HttpHandler\HttpClientCache;
 use Google\Auth\Tests\BaseTest;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use Prophecy\Argument;
 
 /**
@@ -136,7 +137,7 @@ class GCECredentialsTest extends BaseTest
         $jsonTokens = json_encode($wantedTokens);
         $httpHandler = getHandler([
             buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-            buildResponse(200, [], Psr7\stream_for($jsonTokens)),
+            buildResponse(200, [], Utils::streamFor($jsonTokens)),
         ]);
         $g = new GCECredentials();
         $receivedToken = $g->fetchAuthToken($httpHandler);
@@ -165,7 +166,7 @@ class GCECredentialsTest extends BaseTest
                 'audience=a+target+audience',
                 $request->getUri()->getQuery()
             );
-            return new Psr7\Response(200, [], Psr7\stream_for($expectedToken['id_token']));
+            return new Psr7\Response(200, [], Utils::streamFor($expectedToken['id_token']));
         };
         $g = new GCECredentials(null, null, 'a+target+audience');
         $this->assertEquals($expectedToken, $g->fetchAuthToken($httpHandler));
@@ -195,7 +196,7 @@ class GCECredentialsTest extends BaseTest
                 $this->send(Argument::any(), Argument::any())->will(function ($args) use (&$uri) {
                     $uri = $args[0]->getUri();
 
-                    return buildResponse(200, [], Psr7\stream_for('{"expires_in": 0}'));
+                    return buildResponse(200, [], Utils::streamFor('{"expires_in": 0}'));
                 });
 
                 return buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']);
@@ -233,8 +234,8 @@ class GCECredentialsTest extends BaseTest
 
         $httpHandler = getHandler([
             buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-            buildResponse(200, [], Psr7\stream_for($expected)),
-            buildResponse(200, [], Psr7\stream_for('notexpected'))
+            buildResponse(200, [], Utils::streamFor($expected)),
+            buildResponse(200, [], Utils::streamFor('notexpected'))
         ]);
 
         $creds = new GCECredentials();
@@ -280,8 +281,8 @@ class GCECredentialsTest extends BaseTest
         $client->send(Argument::any(), Argument::any())
             ->willReturn(
                 buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-                buildResponse(200, [], Psr7\stream_for($expectedEmail)),
-                buildResponse(200, [], Psr7\stream_for(json_encode($token)))
+                buildResponse(200, [], Utils::streamFor($expectedEmail)),
+                buildResponse(200, [], Utils::streamFor(json_encode($token)))
             );
 
         HttpClientCache::setHttpClient($client->reveal());
@@ -319,9 +320,9 @@ class GCECredentialsTest extends BaseTest
         $client->send(Argument::any(), Argument::any())
             ->willReturn(
                 buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-                buildResponse(200, [], Psr7\stream_for(json_encode($token1))),
-                buildResponse(200, [], Psr7\stream_for($expectedEmail)),
-                buildResponse(200, [], Psr7\stream_for(json_encode($token2)))
+                buildResponse(200, [], Utils::streamFor(json_encode($token1))),
+                buildResponse(200, [], Utils::streamFor($expectedEmail)),
+                buildResponse(200, [], Utils::streamFor(json_encode($token2)))
             );
 
         HttpClientCache::setHttpClient($client->reveal());
@@ -343,8 +344,8 @@ class GCECredentialsTest extends BaseTest
         $client->send(Argument::any(), Argument::any())
             ->willReturn(
                 buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-                buildResponse(200, [], Psr7\stream_for($expected)),
-                buildResponse(200, [], Psr7\stream_for('notexpected'))
+                buildResponse(200, [], Utils::streamFor($expected)),
+                buildResponse(200, [], Utils::streamFor('notexpected'))
             );
 
         HttpClientCache::setHttpClient($client->reveal());
@@ -401,7 +402,7 @@ class GCECredentialsTest extends BaseTest
                 $request->getUri()->getPath()
             );
             $this->assertEquals('', $request->getUri()->getQuery());
-            return new Psr7\Response(200, [], Psr7\stream_for(json_encode($expected)));
+            return new Psr7\Response(200, [], Utils::streamFor(json_encode($expected)));
         };
 
         $g = new GCECredentials(null, null, null, null, 'foo');
@@ -428,7 +429,7 @@ class GCECredentialsTest extends BaseTest
                 'audience=a+target+audience',
                 $request->getUri()->getQuery()
             );
-            return new Psr7\Response(200, [], Psr7\stream_for($expected));
+            return new Psr7\Response(200, [], Utils::streamFor($expected));
         };
         $g = new GCECredentials(null, null, 'a+target+audience', null, 'foo');
         $this->assertEquals(
@@ -460,7 +461,7 @@ class GCECredentialsTest extends BaseTest
                 $request->getUri()->getPath()
             );
             $this->assertEquals('', $request->getUri()->getQuery());
-            return new Psr7\Response(200, [], Psr7\stream_for($expected));
+            return new Psr7\Response(200, [], Utils::streamFor($expected));
         };
 
         $creds = new GCECredentials(null, null, null, null, 'foo');

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -23,6 +23,7 @@ use Google\Auth\Credentials\ServiceAccountJwtAccessCredentials;
 use Google\Auth\CredentialsLoader;
 use Google\Auth\OAuth2;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 
 // Creates a standard JSON auth object for testing.
@@ -292,7 +293,7 @@ class SACFetchAuthTokenTest extends TestCase
         $testJsonText = json_encode($testJson);
         $scope = ['scope/1', 'scope/2'];
         $httpHandler = getHandler([
-            buildResponse(200, [], Psr7\stream_for($testJsonText)),
+            buildResponse(200, [], Utils::streamFor($testJsonText)),
         ]);
         $sa = new ServiceAccountCredentials(
             $scope,
@@ -309,7 +310,7 @@ class SACFetchAuthTokenTest extends TestCase
         $access_token = 'accessToken123';
         $responseText = json_encode(array('access_token' => $access_token));
         $httpHandler = getHandler([
-            buildResponse(200, [], Psr7\stream_for($responseText)),
+            buildResponse(200, [], Utils::streamFor($responseText)),
         ]);
         $sa = new ServiceAccountCredentials(
             $scope,
@@ -348,7 +349,7 @@ class SACFetchAuthTokenTest extends TestCase
             $this->assertArrayHasKey('target_audience', $jwtParams);
             $this->assertEquals('a target audience', $jwtParams['target_audience']);
 
-            return new Psr7\Response(200, [], Psr7\stream_for(json_encode($expectedToken)));
+            return new Psr7\Response(200, [], Utils::streamFor(json_encode($expectedToken)));
         };
         $sa = new ServiceAccountCredentials(null, $testJson, null, 'a target audience');
         $this->assertEquals($expectedToken, $sa->fetchAuthToken($httpHandler));

--- a/tests/Credentials/UserRefreshCredentialsTest.php
+++ b/tests/Credentials/UserRefreshCredentialsTest.php
@@ -20,7 +20,7 @@ namespace Google\Auth\Tests\Credentials;
 use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Credentials\UserRefreshCredentials;
 use Google\Auth\OAuth2;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 
 // Creates a standard JSON auth object for testing.
@@ -258,7 +258,7 @@ class URCFetchAuthTokenTest extends TestCase
         $testJsonText = json_encode($testJson);
         $scope = ['scope/1', 'scope/2'];
         $httpHandler = getHandler([
-            buildResponse(200, [], Psr7\stream_for($testJsonText)),
+            buildResponse(200, [], Utils::streamFor($testJsonText)),
         ]);
         $sa = new UserRefreshCredentials(
             $scope,

--- a/tests/IamTest.php
+++ b/tests/IamTest.php
@@ -19,6 +19,7 @@ namespace Google\Auth\Tests;
 
 use Google\Auth\Iam;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -68,7 +69,7 @@ class IamTest extends TestCase
                 'payload' => base64_encode($expectedString)
             ], json_decode((string) $request->getBody(), true));
 
-            return new Psr7\Response(200, [], Psr7\stream_for(json_encode([
+            return new Psr7\Response(200, [], Utils::streamFor(json_encode([
                 'signedBlob' => $expectedResponse
             ])));
         };

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -18,7 +18,8 @@
 namespace Google\Auth\Tests;
 
 use Google\Auth\OAuth2;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Query;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 
 class OAuth2AuthorizationUriTest extends TestCase
@@ -119,7 +120,7 @@ class OAuth2AuthorizationUriTest extends TestCase
     public function testHasDefaultXXXTypeParams()
     {
         $o = new OAuth2($this->minimal);
-        $q = Psr7\parse_query($o->buildFullAuthorizationUri()->getQuery());
+        $q = Query::parse($o->buildFullAuthorizationUri()->getQuery());
         $this->assertEquals('code', $q['response_type']);
         $this->assertEquals('offline', $q['access_type']);
     }
@@ -127,7 +128,7 @@ class OAuth2AuthorizationUriTest extends TestCase
     public function testCanBeUrlObject()
     {
         $config = array_merge($this->minimal, [
-            'authorizationUri' => Psr7\uri_for('https://another/uri'),
+            'authorizationUri' => Utils::uriFor('https://another/uri'),
         ]);
         $o = new OAuth2($config);
         $this->assertEquals('/uri', $o->buildFullAuthorizationUri()->getPath());
@@ -144,7 +145,7 @@ class OAuth2AuthorizationUriTest extends TestCase
         ];
         $config = array_merge($this->minimal, ['state' => 'the_state']);
         $o = new OAuth2($config);
-        $q = Psr7\parse_query($o->buildFullAuthorizationUri($overrides)->getQuery());
+        $q = Query::parse($o->buildFullAuthorizationUri($overrides)->getQuery());
         $this->assertEquals('o_access_type', $q['access_type']);
         $this->assertEquals('o_client_id', $q['client_id']);
         $this->assertEquals('o_redirect_uri', $q['redirect_uri']);
@@ -156,14 +157,14 @@ class OAuth2AuthorizationUriTest extends TestCase
     {
         $with_strings = array_merge($this->minimal, ['scope' => 'scope1 scope2']);
         $o = new OAuth2($with_strings);
-        $q = Psr7\parse_query($o->buildFullAuthorizationUri()->getQuery());
+        $q = Query::parse($o->buildFullAuthorizationUri()->getQuery());
         $this->assertEquals('scope1 scope2', $q['scope']);
 
         $with_array = array_merge($this->minimal, [
             'scope' => ['scope1', 'scope2'],
         ]);
         $o = new OAuth2($with_array);
-        $q = Psr7\parse_query($o->buildFullAuthorizationUri()->getQuery());
+        $q = Query::parse($o->buildFullAuthorizationUri()->getQuery());
         $this->assertEquals('scope1 scope2', $q['scope']);
     }
 
@@ -589,7 +590,7 @@ class OAuth2GenerateAccessTokenRequestTest extends TestCase
         $req = $o->generateCredentialsRequest();
         $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
         $this->assertEquals('POST', $req->getMethod());
-        $fields = Psr7\parse_query((string)$req->getBody());
+        $fields = Query::parse((string)$req->getBody());
         $this->assertEquals('authorization_code', $fields['grant_type']);
         $this->assertEquals('an_auth_code', $fields['code']);
     }
@@ -605,7 +606,7 @@ class OAuth2GenerateAccessTokenRequestTest extends TestCase
         $req = $o->generateCredentialsRequest();
         $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
         $this->assertEquals('POST', $req->getMethod());
-        $fields = Psr7\parse_query((string)$req->getBody());
+        $fields = Query::parse((string)$req->getBody());
         $this->assertEquals('password', $fields['grant_type']);
         $this->assertEquals('a_password', $fields['password']);
         $this->assertEquals('a_username', $fields['username']);
@@ -621,7 +622,7 @@ class OAuth2GenerateAccessTokenRequestTest extends TestCase
         $req = $o->generateCredentialsRequest();
         $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
         $this->assertEquals('POST', $req->getMethod());
-        $fields = Psr7\parse_query((string)$req->getBody());
+        $fields = Query::parse((string)$req->getBody());
         $this->assertEquals('refresh_token', $fields['grant_type']);
         $this->assertEquals('a_refresh_token', $fields['refresh_token']);
     }
@@ -634,7 +635,7 @@ class OAuth2GenerateAccessTokenRequestTest extends TestCase
         $o = new OAuth2($testConfig);
         $o->setCode('an_auth_code');
         $request = $o->generateCredentialsRequest();
-        $fields = Psr7\parse_query((string)$request->getBody());
+        $fields = Query::parse((string)$request->getBody());
         $this->assertEquals('a_client_secret', $fields['client_secret']);
     }
 
@@ -645,7 +646,7 @@ class OAuth2GenerateAccessTokenRequestTest extends TestCase
         $o = new OAuth2($testConfig);
         $o->setRefreshToken('a_refresh_token');
         $request = $o->generateCredentialsRequest();
-        $fields = Psr7\parse_query((string)$request->getBody());
+        $fields = Query::parse((string)$request->getBody());
         $this->assertEquals('a_client_secret', $fields['client_secret']);
     }
 
@@ -657,7 +658,7 @@ class OAuth2GenerateAccessTokenRequestTest extends TestCase
         $o->setUsername('a_username');
         $o->setPassword('a_password');
         $request = $o->generateCredentialsRequest();
-        $fields = Psr7\parse_query((string)$request->getBody());
+        $fields = Query::parse((string)$request->getBody());
         $this->assertEquals('a_client_secret', $fields['client_secret']);
     }
 
@@ -672,7 +673,7 @@ class OAuth2GenerateAccessTokenRequestTest extends TestCase
         $req = $o->generateCredentialsRequest();
         $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
         $this->assertEquals('POST', $req->getMethod());
-        $fields = Psr7\parse_query((string)$req->getBody());
+        $fields = Query::parse((string)$req->getBody());
         $this->assertEquals(OAuth2::JWT_URN, $fields['grant_type']);
         $this->assertArrayHasKey('assertion', $fields);
     }
@@ -688,7 +689,7 @@ class OAuth2GenerateAccessTokenRequestTest extends TestCase
         $req = $o->generateCredentialsRequest();
         $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $req);
         $this->assertEquals('POST', $req->getMethod());
-        $fields = Psr7\parse_query((string)$req->getBody());
+        $fields = Query::parse((string)$req->getBody());
         $this->assertEquals('my_value', $fields['my_param']);
         $this->assertEquals('urn:my_test_grant_type', $fields['grant_type']);
     }
@@ -741,7 +742,7 @@ class OAuth2FetchAuthTokenTest extends TestCase
         $testConfig = $this->fetchAuthTokenMinimal;
         $notJson = '{"foo": , this is cannot be passed as json" "bar"}';
         $httpHandler = getHandler([
-            buildResponse(200, [], Psr7\stream_for($notJson)),
+            buildResponse(200, [], Utils::streamFor($notJson)),
         ]);
         $o = new OAuth2($testConfig);
         $o->fetchAuthToken($httpHandler);
@@ -752,7 +753,7 @@ class OAuth2FetchAuthTokenTest extends TestCase
         $testConfig = $this->fetchAuthTokenMinimal;
         $json = '{"foo": "bar"}';
         $httpHandler = getHandler([
-            buildResponse(200, [], Psr7\stream_for($json)),
+            buildResponse(200, [], Utils::streamFor($json)),
         ]);
         $o = new OAuth2($testConfig);
         $tokens = $o->fetchAuthToken($httpHandler);
@@ -767,7 +768,7 @@ class OAuth2FetchAuthTokenTest extends TestCase
             buildResponse(
                 200,
                 ['Content-Type' => 'application/x-www-form-urlencoded'],
-                Psr7\stream_for($json)
+                Utils::streamFor($json)
             ),
         ]);
         $o = new OAuth2($testConfig);
@@ -789,7 +790,7 @@ class OAuth2FetchAuthTokenTest extends TestCase
         ];
         $json = json_encode($wanted_updates);
         $httpHandler = getHandler([
-            buildResponse(200, [], Psr7\stream_for($json)),
+            buildResponse(200, [], Utils::streamFor($json)),
         ]);
         $o = new OAuth2($testConfig);
         $this->assertNull($o->getExpiresAt());
@@ -820,7 +821,7 @@ class OAuth2FetchAuthTokenTest extends TestCase
         ];
         $json = json_encode($wanted_updates);
         $httpHandler = getHandler([
-            buildResponse(200, [], Psr7\stream_for($json)),
+            buildResponse(200, [], Utils::streamFor($json)),
         ]);
         $o = new OAuth2($testConfig);
         $this->assertNull($o->getExpiresAt());


### PR DESCRIPTION
Replaced the use of deprecated functions in **guzzlehttp/psr7** for googleapis/google-cloud-php#4247

This is done so that we can use 1.x and 2.x branches of the **guzzlehttp/psr7** package.

The version in composer.json has been bumped to a **minimum of 1.7** because the alternatives to the deprecated versions are available starting **1.7**