### PR TITLE
chore: add explicit return types to address Symfony deprecations

### DIFF
--- a/src/Cache/MemoryCacheItemPool.php
+++ b/src/Cache/MemoryCacheItemPool.php
@@ -37,6 +37,9 @@ final class MemoryCacheItemPool implements CacheItemPoolInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return CacheItemInterface
+     *   The corresponding Cache Item.
      */
     public function getItem($key)
     {
@@ -45,6 +48,12 @@ final class MemoryCacheItemPool implements CacheItemPoolInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return array
+     *   A traversable collection of Cache Items keyed by the cache keys of
+     *   each item. A Cache item will be returned for each key, even if that
+     *   key is not found. However, if no keys are specified then an empty
+     *   traversable MUST be returned instead.
      */
     public function getItems(array $keys = [])
     {
@@ -59,6 +68,9 @@ final class MemoryCacheItemPool implements CacheItemPoolInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
+     *   True if item exists in the cache, false otherwise.
      */
     public function hasItem($key)
     {
@@ -69,6 +81,9 @@ final class MemoryCacheItemPool implements CacheItemPoolInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
+     *   True if the pool was successfully cleared. False if there was an error.
      */
     public function clear()
     {
@@ -80,6 +95,9 @@ final class MemoryCacheItemPool implements CacheItemPoolInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
+     *   True if the item was successfully removed. False if there was an error.
      */
     public function deleteItem($key)
     {
@@ -88,6 +106,9 @@ final class MemoryCacheItemPool implements CacheItemPoolInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
+     *   True if the items were successfully removed. False if there was an error.
      */
     public function deleteItems(array $keys)
     {
@@ -102,6 +123,9 @@ final class MemoryCacheItemPool implements CacheItemPoolInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
+     *   True if the item was successfully persisted. False if there was an error.
      */
     public function save(CacheItemInterface $item)
     {
@@ -112,6 +136,9 @@ final class MemoryCacheItemPool implements CacheItemPoolInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
+     *   False if the item could not be queued or if a commit was attempted and failed. True otherwise.
      */
     public function saveDeferred(CacheItemInterface $item)
     {
@@ -122,6 +149,9 @@ final class MemoryCacheItemPool implements CacheItemPoolInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
+     *   True if all not-yet-saved items were successfully saved or there were none. False otherwise.
      */
     public function commit()
     {


### PR DESCRIPTION
This is meant to address a similar issue to what was done in this merge request:
https://github.com/googleapis/google-api-php-client/pull/2200

The deprecation checking functionality explicitly ignores the use of `inheritDoc`
so we need to add the return types explicitly here. Reference:
https://github.com/symfony/symfony/issues/44802#issuecomment-1001776200