### PR TITLE
Upgrade firebase/php-jwt to ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   },
   "require": {
     "php": ">=5.6",
-    "firebase/php-jwt": "~5.0",
+    "firebase/php-jwt": "^6.0",
     "guzzlehttp/guzzle": "^6.2.1|^7.0",
     "guzzlehttp/psr7": "^1.7|^2.0",
     "psr/http-message": "^1.0",

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -18,6 +18,7 @@
 namespace Google\Auth;
 
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Google\Auth\HttpHandler\HttpClientCache;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use GuzzleHttp\Psr7\Query;
@@ -380,7 +381,7 @@ class OAuth2 implements FetchAuthTokenInterface
      * `\InvalidArgumentException`.
      *
      * @param string $publicKey The public key to use to authenticate the token
-     * @param array $allowed_algs List of supported verification algorithms
+     * @param string $allowed_alg The supported verification algorithm
      * @throws \DomainException if the token is missing an audience.
      * @throws \DomainException if the audience does not match the one set in
      *         the OAuth2 class instance.
@@ -390,14 +391,14 @@ class OAuth2 implements FetchAuthTokenInterface
      * @throws ExpiredException If the token has expired.
      * @return null|object
      */
-    public function verifyIdToken($publicKey = null, $allowed_algs = array())
+    public function verifyIdToken($publicKey = null, $allowed_alg)
     {
         $idToken = $this->getIdToken();
         if (is_null($idToken)) {
             return null;
         }
 
-        $resp = $this->jwtDecode($idToken, $publicKey, $allowed_algs);
+        $resp = $this->jwtDecode($idToken, $publicKey, $allowed_alg);
         if (!property_exists($resp, 'aud')) {
             throw new \DomainException('No audience found the id token');
         }
@@ -1377,12 +1378,12 @@ class OAuth2 implements FetchAuthTokenInterface
     /**
      * @param string $idToken
      * @param string|array|null $publicKey
-     * @param array $allowedAlgs
+     * @param string $allowedAlg
      * @return object
      */
-    private function jwtDecode($idToken, $publicKey, $allowedAlgs)
+    private function jwtDecode($idToken, $publicKey, $allowedAlg)
     {
-        return JWT::decode($idToken, $publicKey, $allowedAlgs);
+        return JWT::decode($idToken, new Key($publicKey, $allowedAlg));
     }
 
     private function jwtEncode($assertion, $signingKey, $signingAlgorithm, $signingKeyId = null)

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -19,6 +19,7 @@ namespace Google\Auth\Tests\Credentials;
 
 use DomainException;
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Auth\Credentials\ServiceAccountJwtAccessCredentials;
@@ -800,7 +801,7 @@ class SACJwtAccessComboTest extends TestCase
         $token = str_replace('Bearer ', '', $metadata['authorization'][0]);
         $key = file_get_contents(__DIR__ . '/../fixtures3/key.pub');
 
-        $result = JWT::decode($token, $key, ['RS256']);
+        $result = JWT::decode($token, new Key($key, 'RS256'));
 
         $this->assertEquals($authUri, $result->aud);
     }

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -19,6 +19,7 @@ namespace Google\Auth\Tests;
 
 use DomainException;
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Google\Auth\OAuth2;
 use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Utils;
@@ -450,7 +451,10 @@ class OAuth2JwtTest extends TestCase
         $testConfig['signingKeyId'] = 'example_key_id2';
         $o = new OAuth2($testConfig);
         $payload = $o->toJwt();
-        $roundTrip = JWT::decode($payload, $keys, array('HS256'));
+        $roundTrip = JWT::decode($payload, array(
+            'example_key_id1' => new Key('example_key1', 'HS256'),
+            'example_key_id2' => new Key('example_key2', 'HS256')
+        ));
         $this->assertEquals($roundTrip->iss, $testConfig['issuer']);
         $this->assertEquals($roundTrip->aud, $testConfig['audience']);
         $this->assertEquals($roundTrip->scope, $testConfig['scope']);
@@ -468,7 +472,10 @@ class OAuth2JwtTest extends TestCase
         $payload = $o->toJwt();
 
         try {
-            JWT::decode($payload, $keys, array('HS256'));
+            JWT::decode($payload, array(
+                'example_key_id1' => new Key('example_key1', 'HS256'),
+                'example_key_id2' => new Key('example_key2', 'HS256')
+            ));
         } catch (\Exception $e) {
             // Workaround: In old JWT versions throws DomainException
             $this->assertTrue(
@@ -485,7 +492,7 @@ class OAuth2JwtTest extends TestCase
         $testConfig = $this->signingMinimal;
         $o = new OAuth2($testConfig);
         $payload = $o->toJwt();
-        $roundTrip = JWT::decode($payload, $testConfig['signingKey'], array('HS256'));
+        $roundTrip = JWT::decode($payload, new Key($testConfig['signingKey'], 'HS256'));
         $this->assertEquals($roundTrip->iss, $testConfig['issuer']);
         $this->assertEquals($roundTrip->aud, $testConfig['audience']);
         $this->assertEquals($roundTrip->scope, $testConfig['scope']);
@@ -500,7 +507,7 @@ class OAuth2JwtTest extends TestCase
         $o->setSigningAlgorithm('RS256');
         $o->setSigningKey($privateKey);
         $payload = $o->toJwt();
-        $roundTrip = JWT::decode($payload, $publicKey, array('RS256'));
+        $roundTrip = JWT::decode($payload, new Key($publicKey, 'RS256'));
         $this->assertEquals($roundTrip->iss, $testConfig['issuer']);
         $this->assertEquals($roundTrip->aud, $testConfig['audience']);
         $this->assertEquals($roundTrip->scope, $testConfig['scope']);
@@ -517,7 +524,7 @@ class OAuth2JwtTest extends TestCase
         $o->setSigningAlgorithm('RS256');
         $o->setSigningKey($privateKey);
         $payload = $o->toJwt();
-        $roundTrip = JWT::decode($payload, $publicKey, array('RS256'));
+        $roundTrip = JWT::decode($payload, new Key($publicKey, 'RS256'));
         $this->assertEquals($roundTrip->target_audience, $targetAud);
     }
 }
@@ -907,7 +914,7 @@ class OAuth2VerifyIdTokenTest extends TestCase
         $not_a_jwt = 'not a jot';
         $o = new OAuth2($testConfig);
         $o->setIdToken($not_a_jwt);
-        $o->verifyIdToken($this->publicKey);
+        $o->verifyIdToken($this->publicKey, 'RS256');
     }
 
     public function testFailsIfAudienceIsMissing()
@@ -923,7 +930,7 @@ class OAuth2VerifyIdTokenTest extends TestCase
         $o = new OAuth2($testConfig);
         $jwtIdToken = JWT::encode($origIdToken, $this->privateKey, 'RS256');
         $o->setIdToken($jwtIdToken);
-        $o->verifyIdToken($this->publicKey, ['RS256']);
+        $o->verifyIdToken($this->publicKey, 'RS256');
     }
 
     public function testFailsIfAudienceIsWrong()
@@ -940,7 +947,7 @@ class OAuth2VerifyIdTokenTest extends TestCase
         $o = new OAuth2($testConfig);
         $jwtIdToken = JWT::encode($origIdToken, $this->privateKey, 'RS256');
         $o->setIdToken($jwtIdToken);
-        $o->verifyIdToken($this->publicKey, ['RS256']);
+        $o->verifyIdToken($this->publicKey, 'RS256');
     }
 
     public function testShouldReturnAValidIdToken()
@@ -957,7 +964,7 @@ class OAuth2VerifyIdTokenTest extends TestCase
         $alg = 'RS256';
         $jwtIdToken = JWT::encode($origIdToken, $this->privateKey, $alg);
         $o->setIdToken($jwtIdToken);
-        $roundTrip = $o->verifyIdToken($this->publicKey, array($alg));
+        $roundTrip = $o->verifyIdToken($this->publicKey, $alg);
         $this->assertEquals($origIdToken['aud'], $roundTrip->aud);
     }
 }


### PR DESCRIPTION
The firebase/php-jwt package recently had to make breaking changes to resolve a security flaw in their library. This change upgrades that library and fixes the code that broke with the upgrade.

Most notably it changes OAuth2::verifyIdToken to only support a single algorithm to bring it inline with the way Jwt::decode works.

You can find more information about the fixes to the firebase/php-jwt here:
https://github.com/firebase/php-jwt/releases/tag/v6.0.0
https://github.com/firebase/php-jwt/issues/351
https://security.snyk.io/vuln/SNYK-PHP-FIREBASEPHPJWT-2434829

I also saw there was a [renovote bot PR](https://github.com/googleapis/google-auth-library-php/pull/386) for this but it didn't fix the code so I thought this might be an opportunity to lend a hand.

Hope this helps! Let me know if there's something else I can do to get this merged. Thanks! 😄