### PR TITLE
Add composer.json support for psr/cache v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "guzzlehttp/guzzle": "^6.2.1|^7.0",
     "guzzlehttp/psr7": "^1.7|^2.0",
     "psr/http-message": "^1.0",
-    "psr/cache": "^1.0|^2.0"
+    "psr/cache": "^1.0|^2.0|^3.0"
   },
   "require-dev": {
     "guzzlehttp/promises": "0.1.1|^1.3",


### PR DESCRIPTION
This fixes the issue I reported at https://github.com/googleapis/google-cloud-php/issues/5205.

When using PHP 8.1 it's becoming common to have packages that require `psr/cache:^3` (in my case: `symfony/cache-contracts:v3.0.0`).

`google/auth:v1.19.0` still requires `psr/cache ^1.0|^2.0`. This is preventing me from installing google/cloud-vision.

The only change with `psr/cache:^3.0` is adding return types for PHP 8.0+, so you can support it as an option as it does not introduce any other changes.