### PR TITLE
chore: export-ignore phpstan.neon, add single_quote to cs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 .gitattributes export-ignore
 .github export-ignore
 .gitignore export-ignore
-phpcs-ruleset.xml export-ignore
+phpstan.neon.dist export-ignore
 phpunit.xml.dist export-ignore
 .php-cs-fixer.dist.php export-ignore
 CHANGELOG.md export-ignore

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -16,6 +16,7 @@ return (new PhpCsFixer\Config())
         'return_type_declaration' => [
             'space_before' => 'none'
         ],
+        'single_quote' => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -478,7 +478,7 @@ class OAuth2JwtTest extends TestCase
             );
             return;
         }
-        $this->fail("Expected exception about problem with decode");
+        $this->fail('Expected exception about problem with decode');
     }
 
     public function testCanHS256EncodeAValidPayload()


### PR DESCRIPTION
Misc fixes

 - add `phpstan.neon.dist` to `.gitattributes` export-ignore
 - require single quotes when possible in CS check