### PR TITLE
fix: `CredentialsLoader` should support `id_token`

### DIFF
--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -212,13 +212,17 @@ abstract class CredentialsLoader implements
             return $metadata;
         }
         $result = $this->fetchAuthToken($httpHandler);
-        if (!isset($result['access_token'])) {
+        if (isset($result['access_token'])) {
+            $metadata_copy = $metadata;
+            $metadata_copy[self::AUTH_METADATA_KEY] = ['Bearer ' . $result['access_token']];
+            return $metadata_copy;
+        } else if (isset($result['id_token'])) {
+            $metadata_copy = $metadata;
+            $metadata_copy[self::AUTH_METADATA_KEY] = ['Bearer ' . $result['id_token']];
+            return $metadata_copy;
+        } else {
             return $metadata;
         }
-        $metadata_copy = $metadata;
-        $metadata_copy[self::AUTH_METADATA_KEY] = ['Bearer ' . $result['access_token']];
-
-        return $metadata_copy;
     }
 
     /**

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -212,17 +212,13 @@ abstract class CredentialsLoader implements
             return $metadata;
         }
         $result = $this->fetchAuthToken($httpHandler);
+        $metadata_copy = $metadata;
         if (isset($result['access_token'])) {
-            $metadata_copy = $metadata;
             $metadata_copy[self::AUTH_METADATA_KEY] = ['Bearer ' . $result['access_token']];
-            return $metadata_copy;
         } elseif (isset($result['id_token'])) {
-            $metadata_copy = $metadata;
             $metadata_copy[self::AUTH_METADATA_KEY] = ['Bearer ' . $result['id_token']];
-            return $metadata_copy;
-        } else {
-            return $metadata;
         }
+        return $metadata_copy;
     }
 
     /**

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -216,7 +216,7 @@ abstract class CredentialsLoader implements
             $metadata_copy = $metadata;
             $metadata_copy[self::AUTH_METADATA_KEY] = ['Bearer ' . $result['access_token']];
             return $metadata_copy;
-        } else if (isset($result['id_token'])) {
+        } elseif (isset($result['id_token'])) {
             $metadata_copy = $metadata;
             $metadata_copy[self::AUTH_METADATA_KEY] = ['Bearer ' . $result['id_token']];
             return $metadata_copy;


### PR DESCRIPTION
Currently, the following code doesn't work because the `public function updateMetadata` implementation in `CredentialsLoader` only checks for `access_token` but not `id_token`.
```
  $target_audience = 'https://some-endpoint.a.run.app/';  // A service deployed on Google Cloud Run
  $auth_credentials = ApplicationDefaultCredentials::getIdTokenCredentials($target_audience);
  $updated = $auth_credentials->updateMetadata([]); // `$updated` is still empty
```

The proposing CL adds handling for `id_token` which support the above case.