### PR TITLE
chore: better phpdoc for cache items

### DIFF
--- a/src/Cache/Item.php
+++ b/src/Cache/Item.php
@@ -26,8 +26,9 @@ use TypeError;
 /**
  * A cache item.
  *
- * This class is for compatiblility with psr/cache 1.0 and 2.0 (PSR-6).
- * @see TypedItem
+ * This class will be used by MemoryCacheItemPool and SysVCacheItemPool
+ * on PHP 7.4 and below. It is compatible with psr/cache 1.0 and 2.0 (PSR-6).
+ * @see TypedItem for compatiblity with psr/cache 3.0.
  */
 final class Item implements CacheItemInterface
 {

--- a/src/Cache/Item.php
+++ b/src/Cache/Item.php
@@ -27,6 +27,7 @@ use TypeError;
  * A cache item.
  *
  * This class is for compatiblility with psr/cache 1.0 and 2.0 (PSR-6).
+ * @see TypedItem
  */
 final class Item implements CacheItemInterface
 {

--- a/src/Cache/Item.php
+++ b/src/Cache/Item.php
@@ -25,6 +25,8 @@ use TypeError;
 
 /**
  * A cache item.
+ *
+ * This class is for compatiblility with psr/cache 1.0 and 2.0 (PSR-6).
  */
 final class Item implements CacheItemInterface
 {

--- a/src/Cache/TypedItem.php
+++ b/src/Cache/TypedItem.php
@@ -22,8 +22,9 @@ use Psr\Cache\CacheItemInterface;
 /**
  * A cache item.
  *
- * This class works only on PHP 8.0 and above, and is compatible with
- * psr/cache 3.0 (PSR-6).
+ * This class will be used by MemoryCacheItemPool and SysVCacheItemPool
+ * on PHP 8.0 and above. It is compatible with psr/cache 3.0 (PSR-6).
+ * @see Google\Auth\Cache\Item for compatiblity with previous versions of PHP.
  */
 final class TypedItem implements CacheItemInterface
 {

--- a/src/Cache/TypedItem.php
+++ b/src/Cache/TypedItem.php
@@ -21,6 +21,9 @@ use Psr\Cache\CacheItemInterface;
 
 /**
  * A cache item.
+ *
+ * This class works only on PHP 8.0 and above, and is compatible with
+ * psr/cache 3.0 (PSR-6).
  */
 final class TypedItem implements CacheItemInterface
 {

--- a/src/Cache/TypedItem.php
+++ b/src/Cache/TypedItem.php
@@ -24,7 +24,7 @@ use Psr\Cache\CacheItemInterface;
  *
  * This class will be used by MemoryCacheItemPool and SysVCacheItemPool
  * on PHP 8.0 and above. It is compatible with psr/cache 3.0 (PSR-6).
- * @see Google\Auth\Cache\Item for compatiblity with previous versions of PHP.
+ * @see Item for compatiblity with previous versions of PHP.
  */
 final class TypedItem implements CacheItemInterface
 {


### PR DESCRIPTION
addresses #408 by adding clarity on the reason why we have both `Cache\Item` and `Cache\TypedItem`