### PR TITLE
fix: remove Constructor Property Promotion syntax

### DIFF
--- a/src/Cache/TypedItem.php
+++ b/src/Cache/TypedItem.php
@@ -29,6 +29,11 @@ use Psr\Cache\CacheItemInterface;
 final class TypedItem implements CacheItemInterface
 {
     /**
+     * @var string
+     */
+    private string $key;
+    
+    /**
      * @var mixed
      */
     private mixed $value;
@@ -47,7 +52,7 @@ final class TypedItem implements CacheItemInterface
      * @param string $key
      */
     public function __construct(
-        private string $key
+        string $key
     ) {
         $this->key = $key;
         $this->expiration = null;


### PR DESCRIPTION
Addresses: https://github.com/googleapis/google-auth-library-php/issues/412