### PR TITLE
feat: double default truncateAt for guzzle error output

### DIFF
--- a/src/HttpHandler/HttpHandlerFactory.php
+++ b/src/HttpHandler/HttpHandlerFactory.php
@@ -39,7 +39,8 @@ class HttpHandlerFactory
                 // double the # of characters before truncation by default
                 $bodySummarizer = new BodySummarizer(240);
                 $stack = HandlerStack::create();
-                $stack->push(Middleware::httpErrors($bodySummarizer), 'http_errors');
+                $stack->remove('http_errors');
+                $stack->unshift(Middleware::httpErrors($bodySummarizer), 'http_errors');
             }
             $client = new Client(['handler' => $stack]);
         }

--- a/src/HttpHandler/HttpHandlerFactory.php
+++ b/src/HttpHandler/HttpHandlerFactory.php
@@ -18,6 +18,9 @@ namespace Google\Auth\HttpHandler;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\BodySummarizer;
 
 class HttpHandlerFactory
 {
@@ -30,7 +33,16 @@ class HttpHandlerFactory
      */
     public static function build(ClientInterface $client = null)
     {
-        $client = $client ?: new Client();
+        if (is_null($client)) {
+            $stack = null;
+            if (class_exists(BodySummarizer::class)) {
+                // double the # of characters before truncation by default
+                $bodySummarizer = new BodySummarizer(240);
+                $stack = HandlerStack::create();
+                $stack->push(Middleware::httpErrors($bodySummarizer), 'http_errors');
+            }
+            $client = new Client(['handler' => $stack]);
+        }
 
         $version = null;
         if (defined('GuzzleHttp\ClientInterface::MAJOR_VERSION')) {

--- a/src/HttpHandler/HttpHandlerFactory.php
+++ b/src/HttpHandler/HttpHandlerFactory.php
@@ -16,11 +16,11 @@
  */
 namespace Google\Auth\HttpHandler;
 
+use GuzzleHttp\BodySummarizer;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
-use GuzzleHttp\BodySummarizer;
 
 class HttpHandlerFactory
 {

--- a/tests/HttpHandler/HttpHandlerFactoryTest.php
+++ b/tests/HttpHandler/HttpHandlerFactoryTest.php
@@ -53,7 +53,7 @@ class HttpHandlerFactoryTest extends BaseTest
 
         // Guzzle defaults to 120 characters. We expect to see our message truncated at 240
         $defaultTruncatedLength = 240;
-        $longMessage = str_repeat('x', 2500);
+        $longMessage = str_repeat('x', $defaultTruncatedLength + 1);
         $expectedMessage = str_repeat('x', $defaultTruncatedLength) . ' (truncated...)';
         $this->expectException(RequestException::class);
         $this->expectExceptionMessage($expectedMessage);


### PR DESCRIPTION
**_Guzzle 7 Only_**

This will help the user receive a more helpful error message when encountering Google API exceptions. For example, with the "reAuth" error:

**Before**
```
Fatal error: Uncaught GuzzleHttp\Exception\ClientException: Client error: `POST https://oauth2.googleapis.com/token` resulted in a `400 Bad Request` response:
{
  "error": "invalid_grant",
  "error_description": "reauth related error (rapt_required)",
  "error_uri": "https://sup (truncated...)
 in /path/to/project/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php:113
```

**After**
```
Fatal error: Uncaught GuzzleHttp\Exception\ClientException: Client error: `POST https://oauth2.googleapis.com/token` resulted in a `400 Bad Request` response:
{
  "error": "invalid_grant",
  "error_description": "reauth related error (rapt_required)",
  "error_uri": "https://support.google.com/a/answer/9368756",
  "error_subtype": "rapt_required"
}
 in /path/to/project/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php:113
```