### PR TITLE
fix: do not call GCECredentials::onGCE if ADC has already checked

### DIFF
--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -183,6 +183,7 @@ class ApplicationDefaultCredentials
             $creds = new AppIdentityCredentials($anyScope);
         } elseif (self::onGce($httpHandler, $cacheConfig, $cache)) {
             $creds = new GCECredentials(null, $anyScope, null, $quotaProject);
+            $creds->setIsOnGce(true); // save the credentials a trip to the metadata server
         }
 
         if (is_null($creds)) {
@@ -297,6 +298,7 @@ class ApplicationDefaultCredentials
             $creds = new ServiceAccountCredentials(null, $jsonKey, null, $targetAudience);
         } elseif (self::onGce($httpHandler, $cacheConfig, $cache)) {
             $creds = new GCECredentials(null, null, $targetAudience);
+            $creds->setIsOnGce(true); // save the credentials a trip to the metadata server
         }
 
         if (is_null($creds)) {

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -547,7 +547,7 @@ class GCECredentials extends CredentialsLoader implements
     }
 
     /**
-     * Set whether or not
+     * Set whether or not we've already checked the GCE environment.
      *
      * @param bool $isOnGce
      */

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -545,4 +545,17 @@ class GCECredentials extends CredentialsLoader implements
     {
         return $this->quotaProject;
     }
+
+    /**
+     * Set whether or not
+     *
+     * @param bool $isOnGce
+     */
+    public function setIsOnGce($isOnGce)
+    {
+        // Implicitly set hasCheckedGce to true
+        $this->hasCheckedOnGce = true;
+
+        $this->isOnGce = $isOnGce;
+    }
 }

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -556,6 +556,7 @@ class GCECredentials extends CredentialsLoader implements
         // Implicitly set hasCheckedGce to true
         $this->hasCheckedOnGce = true;
 
+        // Set isOnGce
         $this->isOnGce = $isOnGce;
     }
 }

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -550,6 +550,8 @@ class GCECredentials extends CredentialsLoader implements
      * Set whether or not we've already checked the GCE environment.
      *
      * @param bool $isOnGce
+     *
+     * @return void
      */
     public function setIsOnGce($isOnGce)
     {

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -25,7 +25,8 @@ use Google\Auth\Tests\BaseTest;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Response;
 use InvalidArgumentException;
 use Prophecy\Argument;
 
@@ -387,12 +388,10 @@ class GCECredentialsTest extends BaseTest
 
     public function testSetIsOnGceToTrueWhenNotOnGceThrowsException()
     {
-        if (GCECredentials::onGCE()) {
-            $this->markTestSkipped('Must not be on GCE for this test');
-        }
-        $this->expectException(ConnectException::class);
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('408 Request Time-out');
 
-        $httpHandler = HttpHandlerFactory::build(new Client(['timeout' => 0.1]));
+        $httpHandler = getHandler([new Response(408)]);
         $creds = new GCECredentials();
         $creds->setIsOnGce(true);
         $creds->fetchAuthToken($httpHandler);

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -20,13 +20,11 @@ namespace Google\Auth\Tests\Credentials;
 use Exception;
 use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\HttpHandler\HttpClientCache;
-use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Auth\Tests\BaseTest;
-use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\Utils;
-use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use InvalidArgumentException;
 use Prophecy\Argument;
 


### PR DESCRIPTION
Adds a method `GCECredentials::setIsOnGce`, so that if `ApplicationDefaultCredentials` already checks that the library is running on GCE, we do not need to check again in `GCECredentials`.

```php
if (ApplicationDefaultCredentials::onGce()) {
    $creds = new GCECredentials();
    $creds->setIsOnGce(true); // save the credentials a trip to the metadata server
}
```