### PR TITLE
chore: remove phpstan ignore

### DIFF
--- a/src/HttpHandler/HttpHandlerFactory.php
+++ b/src/HttpHandler/HttpHandlerFactory.php
@@ -49,7 +49,6 @@ class HttpHandlerFactory
         if (defined('GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
             $version = ClientInterface::MAJOR_VERSION;
         } elseif (defined('GuzzleHttp\ClientInterface::VERSION')) {
-            /** @phpstan-ignore-next-line */
             $version = (int) substr(ClientInterface::VERSION, 0, 1);
         }
 


### PR DESCRIPTION
The latest version of PHPStan is smart enough to ignore missing references when they're wrapped in a conditional with a call to `defined`, so we no longer have to ignore this line!