### PR TITLE
Replaced getenv/putenv with `$_ENV` and unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Once downloaded, store the path to this file in the
 `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
 
 ```php
-putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
+$_ENV['GOOGLE_APPLICATION_CREDENTIALS'] = '/path/to/my/credentials.json';
 ```
 
-> PHP's `putenv` function is just one way to set an environment variable.
+> PHP's `$_ENV` variable is just one way to set an environment variable.
 > Consider using `.htaccess` or apache configuration files as well.
 
 #### Enable the API you want to use
@@ -83,7 +83,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 
 // specify the path to your application credentials
-putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
+$_ENV['GOOGLE_APPLICATION_CREDENTIALS'] = '/path/to/my/credentials.json';
 
 // define the scopes for your API call
 $scopes = ['https://www.googleapis.com/auth/drive.readonly'];
@@ -136,7 +136,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 
 // specify the path to your application credentials
-putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
+$_ENV['GOOGLE_APPLICATION_CREDENTIALS'] = '/path/to/my/credentials.json';
 
 // Provide the ID token audience. This can be a Client ID associated with an IAP application,
 // Or the URL associated with a CloudRun App
@@ -230,7 +230,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 
 // specify the path to your application credentials
-putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
+$_ENV['GOOGLE_APPLICATION_CREDENTIALS'] = '/path/to/my/credentials.json';
 
 // Provide the ID token audience. This can be a Client ID associated with an IAP application
 //    $targetAudience = 'IAP_CLIENT_ID.apps.googleusercontent.com';

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -432,7 +432,7 @@ class AccessToken
      */
     private function setPhpsecConstants()
     {
-        if (filter_var(getenv('GAE_VM'), FILTER_VALIDATE_BOOLEAN)) {
+        if (filter_var(array_key_exists('GAE_VM', $_ENV) ? $_ENV['GAE_VM'] : false, FILTER_VALIDATE_BOOLEAN)) {
             if (!defined('MATH_BIGINTEGER_OPENSSL_ENABLED')) {
                 define('MATH_BIGINTEGER_OPENSSL_ENABLED', true);
             }

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -297,7 +297,7 @@ class GCECredentials extends CredentialsLoader implements
      */
     public static function onAppEngineFlexible()
     {
-        return substr((string) getenv('GAE_INSTANCE'), 0, 4) === 'aef-';
+        return substr((string) array_key_exists('GAE_INSTANCE', $_ENV) ? $_ENV['GAE_INSTANCE'] : false, 0, 4) === 'aef-';
     }
 
     /**

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -71,7 +71,7 @@ abstract class CredentialsLoader implements
      */
     public static function fromEnv()
     {
-        $path = getenv(self::ENV_VAR);
+        $path = array_key_exists(self::ENV_VAR, $_ENV) ? $_ENV[self::ENV_VAR] : false;
         if (empty($path)) {
             return null;
         }
@@ -98,7 +98,7 @@ abstract class CredentialsLoader implements
     public static function fromWellKnownFile()
     {
         $rootEnv = self::isOnWindows() ? 'APPDATA' : 'HOME';
-        $path = [getenv($rootEnv)];
+        $path = [array_key_exists($rootEnv, $_ENV) ? $_ENV[$rootEnv] : false];
         if (!self::isOnWindows()) {
             $path[] = self::NON_WINDOWS_WELL_KNOWN_PATH_BASE;
         }
@@ -260,7 +260,7 @@ abstract class CredentialsLoader implements
      */
     public static function shouldLoadClientCertSource()
     {
-        return filter_var(getenv(self::MTLS_CERT_ENV_VAR), FILTER_VALIDATE_BOOLEAN);
+        return filter_var((array_key_exists(self::MTLS_CERT_ENV_VAR, $_ENV) ? $_ENV[self::MTLS_CERT_ENV_VAR] : false), FILTER_VALIDATE_BOOLEAN);
     }
 
     /**
@@ -269,7 +269,7 @@ abstract class CredentialsLoader implements
     private static function loadDefaultClientCertSourceFile()
     {
         $rootEnv = self::isOnWindows() ? 'APPDATA' : 'HOME';
-        $path = sprintf('%s/%s', getenv($rootEnv), self::MTLS_WELL_KNOWN_PATH);
+        $path = sprintf('%s/%s', array_key_exists($rootEnv, $_ENV) ? $_ENV[$rootEnv] : false, self::MTLS_WELL_KNOWN_PATH);
         if (!file_exists($path)) {
             return null;
         }

--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -232,7 +232,7 @@ class AccessTokenTest extends TestCase
 
     public function testEsVerifyEndToEnd()
     {
-        if (!$jwt = getenv('IAP_IDENTITY_TOKEN')) {
+        if (!$jwt = array_key_exists('IAP_IDENTITY_TOKEN', $_ENV) ? $_ENV['IAP_IDENTITY_TOKEN'] : false) {
             $this->markTestSkipped('Set the IAP_IDENTITY_TOKEN env var');
         }
 

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -33,15 +33,15 @@ class ADCGetTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->originalHome = getenv('HOME');
+        $this->originalHome = array_key_exists('HOME', $_ENV) ? $_ENV['HOME'] : false;
     }
 
     protected function tearDown(): void
     {
-        if ($this->originalHome != getenv('HOME')) {
-            putenv('HOME=' . $this->originalHome);
+        if ($this->originalHome != array_key_exists('HOME', $_ENV) ? $_ENV['HOME'] : false) {
+            $_ENV['HOME'] = $this->originalHome;
         }
-        putenv(ServiceAccountCredentials::ENV_VAR);  // removes it from
+        unset($_ENV[ServiceAccountCredentials::ENV_VAR]);  // removes environment variable
     }
 
     public function testIsFailsEnvSpecifiesNonExistentFile()
@@ -49,14 +49,14 @@ class ADCGetTest extends TestCase
         $this->expectException(DomainException::class);
 
         $keyFile = __DIR__ . '/fixtures' . '/does-not-exist-private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
         ApplicationDefaultCredentials::getCredentials('a scope');
     }
 
     public function testLoadsOKIfEnvSpecifiedIsValid()
     {
         $keyFile = __DIR__ . '/fixtures' . '/private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
         $this->assertNotNull(
             ApplicationDefaultCredentials::getCredentials('a scope')
         );
@@ -64,7 +64,7 @@ class ADCGetTest extends TestCase
 
     public function testLoadsDefaultFileIfPresentAndEnvVarIsNotSet()
     {
-        putenv('HOME=' . __DIR__ . '/fixtures');
+        $_ENV['HOME'] = __DIR__ . '/fixtures';
         $this->assertNotNull(
             ApplicationDefaultCredentials::getCredentials('a scope')
         );
@@ -74,7 +74,7 @@ class ADCGetTest extends TestCase
     {
         $this->expectException(DomainException::class);
 
-        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+        $_ENV['HOME'] = __DIR__ . '/not_exist_fixtures';
         // simulate not being GCE and retry attempts by returning multiple 500s
         $httpHandler = getHandler([
             buildResponse(500),
@@ -87,7 +87,7 @@ class ADCGetTest extends TestCase
 
     public function testSuccedsIfNoDefaultFilesButIsOnGCE()
     {
-        putenv('HOME');
+        unset($_ENV['HOME']);
 
         $wantedTokens = [
             'access_token' => '1/abdef1234567890',
@@ -114,7 +114,7 @@ class ADCDefaultScopeTest extends TestCase
     /** @runInSeparateProcess */
     public function testGceCredentials()
     {
-        putenv('HOME');
+        unset($_ENV['HOME']);
 
         $jsonTokens = json_encode(['access_token' => 'abc']);
 
@@ -161,7 +161,7 @@ class ADCDefaultScopeTest extends TestCase
 
     public function testImpersonatedServiceAccountCredentials()
     {
-        putenv('HOME=' . __DIR__ . '/fixtures5');
+        $_ENV['HOME'] = __DIR__ . '/fixtures5';
         $creds = ApplicationDefaultCredentials::getCredentials(
             null,
             null,
@@ -189,7 +189,7 @@ class ADCDefaultScopeTest extends TestCase
     /** @runInSeparateProcess */
     public function testUserRefreshCredentials()
     {
-        putenv('HOME=' . __DIR__ . '/fixtures2');
+        $_ENV['HOME'] = __DIR__ . '/fixtures2';
 
         $creds = ApplicationDefaultCredentials::getCredentials(
             null, // $scope
@@ -229,7 +229,7 @@ class ADCDefaultScopeTest extends TestCase
     /** @runInSeparateProcess */
     public function testServiceAccountCredentials()
     {
-        putenv('HOME=' . __DIR__ . '/fixtures');
+        $_ENV['HOME'] = __DIR__ . '/fixtures';
 
         $creds = ApplicationDefaultCredentials::getCredentials(
             null, // $scope
@@ -269,7 +269,7 @@ class ADCDefaultScopeTest extends TestCase
     /** @runInSeparateProcess */
     public function testDefaultScopeArray()
     {
-        putenv('HOME=' . __DIR__ . '/fixtures2');
+        $_ENV['HOME'] = __DIR__ . '/fixtures2';
 
         $creds = ApplicationDefaultCredentials::getCredentials(
             null, // $scope
@@ -295,15 +295,15 @@ class ADCGetMiddlewareTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->originalHome = getenv('HOME');
+        $this->originalHome = array_key_exists('HOME', $_ENV) ? $_ENV['HOME'] : false;
     }
 
     protected function tearDown(): void
     {
-        if ($this->originalHome != getenv('HOME')) {
-            putenv('HOME=' . $this->originalHome);
+        if ($this->originalHome != array_key_exists('HOME', $_ENV) ? $_ENV['HOME'] : false) {
+            $_ENV['HOME'] = $this->originalHome;
         }
-        putenv(ServiceAccountCredentials::ENV_VAR);  // removes it if assigned
+        unset($_ENV[ServiceAccountCredentials::ENV_VAR]);  // removes environment variable
     }
 
     public function testIsFailsEnvSpecifiesNonExistentFile()
@@ -311,20 +311,20 @@ class ADCGetMiddlewareTest extends TestCase
         $this->expectException(DomainException::class);
 
         $keyFile = __DIR__ . '/fixtures' . '/does-not-exist-private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
         ApplicationDefaultCredentials::getMiddleware('a scope');
     }
 
     public function testLoadsOKIfEnvSpecifiedIsValid()
     {
         $keyFile = __DIR__ . '/fixtures' . '/private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
         $this->assertNotNull(ApplicationDefaultCredentials::getMiddleware('a scope'));
     }
 
     public function testLoadsDefaultFileIfPresentAndEnvVarIsNotSet()
     {
-        putenv('HOME=' . __DIR__ . '/fixtures');
+        $_ENV['HOME'] = __DIR__ . '/fixtures';
         $this->assertNotNull(ApplicationDefaultCredentials::getMiddleware('a scope'));
     }
 
@@ -332,7 +332,7 @@ class ADCGetMiddlewareTest extends TestCase
     {
         $this->expectException(DomainException::class);
 
-        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+        $_ENV['HOME'] = __DIR__ . '/not_exist_fixtures';
 
         // simulate not being GCE and retry attempts by returning multiple 500s
         $httpHandler = getHandler([
@@ -347,7 +347,7 @@ class ADCGetMiddlewareTest extends TestCase
     public function testWithCacheOptions()
     {
         $keyFile = __DIR__ . '/fixtures' . '/private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
 
         $httpHandler = getHandler([
             buildResponse(200),
@@ -388,7 +388,7 @@ class ADCGetMiddlewareTest extends TestCase
     {
         $this->expectException(DomainException::class);
 
-        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+        $_ENV['HOME'] = __DIR__ . '/not_exist_fixtures';
 
         $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
         $mockCacheItem->isHit()
@@ -412,7 +412,7 @@ class ADCGetMiddlewareTest extends TestCase
 
     public function testOnGceCacheWithoutHit()
     {
-        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+        $_ENV['HOME'] = __DIR__ . '/not_exist_fixtures';
 
         $gceIsCalled = false;
         $dummyHandler = function ($request) use (&$gceIsCalled) {
@@ -448,7 +448,7 @@ class ADCGetMiddlewareTest extends TestCase
 
     public function testOnGceCacheWithOptions()
     {
-        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+        $_ENV['HOME'] = __DIR__ . '/not_exist_fixtures';
 
         $prefix = 'test_prefix_';
         $lifetime = '70707';
@@ -493,15 +493,15 @@ class ADCGetCredentialsWithTargetAudienceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->originalHome = getenv('HOME');
+        $this->originalHome = array_key_exists('HOME', $_ENV) ? $_ENV['HOME'] : false;
     }
 
     protected function tearDown(): void
     {
-        if ($this->originalHome != getenv('HOME')) {
-            putenv('HOME=' . $this->originalHome);
+        if ($this->originalHome != array_key_exists('HOME', $_ENV) ? $_ENV['HOME'] : false) {
+            $_ENV['HOME'] = $this->originalHome;
         }
-        putenv(ServiceAccountCredentials::ENV_VAR);  // removes environment variable
+        unset($_ENV[ServiceAccountCredentials::ENV_VAR]);  // removes environment variable
     }
 
     public function testIsFailsEnvSpecifiesNonExistentFile()
@@ -509,14 +509,14 @@ class ADCGetCredentialsWithTargetAudienceTest extends TestCase
         $this->expectException(DomainException::class);
 
         $keyFile = __DIR__ . '/fixtures' . '/does-not-exist-private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
         ApplicationDefaultCredentials::getIdTokenCredentials($this->targetAudience);
     }
 
     public function testLoadsOKIfEnvSpecifiedIsValid()
     {
         $keyFile = __DIR__ . '/fixtures' . '/private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
 
         $creds = ApplicationDefaultCredentials::getIdTokenCredentials($this->targetAudience);
 
@@ -525,7 +525,7 @@ class ADCGetCredentialsWithTargetAudienceTest extends TestCase
 
     public function testLoadsDefaultFileIfPresentAndEnvVarIsNotSet()
     {
-        putenv('HOME=' . __DIR__ . '/fixtures');
+        $_ENV['HOME'] = __DIR__ . '/fixtures';
         $creds = ApplicationDefaultCredentials::getIdTokenCredentials($this->targetAudience);
         $this->assertNotNull($creds);
     }
@@ -534,7 +534,7 @@ class ADCGetCredentialsWithTargetAudienceTest extends TestCase
     {
         $this->expectException(DomainException::class);
 
-        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+        $_ENV['HOME'] = __DIR__ . '/not_exist_fixtures';
 
         // simulate not being GCE and retry attempts by returning multiple 500s
         $httpHandler = getHandler([
@@ -554,7 +554,7 @@ class ADCGetCredentialsWithTargetAudienceTest extends TestCase
     public function testWithCacheOptions()
     {
         $keyFile = __DIR__ . '/fixtures' . '/private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
 
         $httpHandler = getHandler([
             buildResponse(200),
@@ -575,7 +575,7 @@ class ADCGetCredentialsWithTargetAudienceTest extends TestCase
 
     public function testSuccedsIfNoDefaultFilesButIsOnGCE()
     {
-        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+        $_ENV['HOME'] = __DIR__ . '/not_exist_fixtures';
         $wantedTokens = [
             'access_token' => '1/abdef1234567890',
             'expires_in' => '57',
@@ -608,21 +608,21 @@ class ADCGetCredentialsWithQuotaProjectTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->originalHome = getenv('HOME');
+        $this->originalHome = $_ENV['HOME'];
     }
 
     protected function tearDown(): void
     {
-        if ($this->originalHome != getenv('HOME')) {
-            putenv('HOME=' . $this->originalHome);
+        if ($this->originalHome != $_ENV['HOME']) {
+            $_ENV['HOME'] = $this->originalHome;
         }
-        putenv(ServiceAccountCredentials::ENV_VAR);  // removes environment variable
+        unset($_ENV[ServiceAccountCredentials::ENV_VAR]);  // removes environment variable
     }
 
     public function testWithServiceAccountCredentialsAndExplicitQuotaProject()
     {
         $keyFile = __DIR__ . '/fixtures' . '/private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
 
         $credentials = ApplicationDefaultCredentials::getCredentials(
             null,
@@ -646,7 +646,7 @@ class ADCGetCredentialsWithQuotaProjectTest extends TestCase
     public function testGetCredentialsUtilizesQuotaProjectInKeyFile()
     {
         $keyFile = __DIR__ . '/fixtures' . '/private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
 
         $credentials = ApplicationDefaultCredentials::getCredentials();
 
@@ -659,7 +659,7 @@ class ADCGetCredentialsWithQuotaProjectTest extends TestCase
     public function testWithFetchAuthTokenCacheAndExplicitQuotaProject()
     {
         $keyFile = __DIR__ . '/fixtures' . '/private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
 
         $httpHandler = getHandler([
             buildResponse(200),
@@ -686,7 +686,7 @@ class ADCGetCredentialsWithQuotaProjectTest extends TestCase
 
     public function testWithGCECredentials()
     {
-        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+        $_ENV['HOME'] =  __DIR__ . '/not_exist_fixtures';
         $wantedTokens = [
             'access_token' => '1/abdef1234567890',
             'expires_in' => '57',
@@ -729,20 +729,20 @@ class ADCGetCredentialsAppEngineTest extends BaseTest
     protected function setUp(): void
     {
         // set home to be somewhere else
-        $this->originalHome = getenv('HOME');
-        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+        $this->originalHome = array_key_exists('HOME', $_ENV) ? $_ENV['HOME'] : false;
+        $_ENV['HOME'] = __DIR__ . '/not_exist_fixtures';
 
         // remove service account path
-        $this->originalServiceAccount = getenv(ServiceAccountCredentials::ENV_VAR);
-        putenv(ServiceAccountCredentials::ENV_VAR);
+        $this->originalServiceAccount = array_key_exists(ServiceAccountCredentials::ENV_VAR, $_ENV) ? $_ENV[ServiceAccountCredentials::ENV_VAR] : false;
+        unset($_ENV[ServiceAccountCredentials::ENV_VAR]);  // removes environment variable
     }
 
     protected function tearDown(): void
     {
         // removes it if assigned
-        putenv('HOME=' . $this->originalHome);
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $this->originalServiceAccount);
-        putenv('GAE_INSTANCE');
+        $_ENV['HOME'] = $this->originalHome;
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $this->originalServiceAccount;
+        unset($_ENV['GAE_INSTANCE']);
     }
 
     /**
@@ -763,7 +763,7 @@ class ADCGetCredentialsAppEngineTest extends BaseTest
     public function testAppEngineFlexible()
     {
         $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
-        putenv('GAE_INSTANCE=aef-default-20180313t154438');
+        $_ENV['GAE_INSTANCE'] = 'aef-default-20180313t154438';
         $httpHandler = getHandler([
             buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
         ]);
@@ -779,7 +779,7 @@ class ADCGetCredentialsAppEngineTest extends BaseTest
     public function testAppEngineFlexibleIdToken()
     {
         $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
-        putenv('GAE_INSTANCE=aef-default-20180313t154438');
+        $_ENV['GAE_INSTANCE'] = 'aef-default-20180313t154438';
         $httpHandler = getHandler([
             buildResponse(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
         ]);

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -93,9 +93,9 @@ class GCECredentialsTest extends BaseTest
 
     public function testOnAppEngineFlexIsTrueWhenGaeInstanceHasAefPrefix()
     {
-        putenv('GAE_INSTANCE=aef-default-20180313t154438');
+        $_ENV['GAE_INSTANCE'] = 'aef-default-20180313t154438';
         $this->assertTrue(GCECredentials::onAppEngineFlexible());
-        putenv('GAE_INSTANCE');
+        unset($_ENV['GAE_INSTANCE']);
     }
 
     public function testGetCacheKeyShouldNotBeEmpty()

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -177,7 +177,7 @@ class SACFromEnvTest extends TestCase
 {
     protected function tearDown(): void
     {
-        putenv(ServiceAccountCredentials::ENV_VAR);  // removes it from
+        unset($_ENV[ServiceAccountCredentials::ENV_VAR]); // removes environment variable
     }
 
     public function testIsNullIfEnvVarIsNotSet()
@@ -189,14 +189,14 @@ class SACFromEnvTest extends TestCase
     {
         $this->expectException(DomainException::class);
         $keyFile = __DIR__ . '/../fixtures' . '/does-not-exist-private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
         ApplicationDefaultCredentials::getCredentials('a scope');
     }
 
     public function testSucceedIfFileExists()
     {
         $keyFile = __DIR__ . '/../fixtures' . '/private.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
         $this->assertNotNull(ApplicationDefaultCredentials::getCredentials('a scope'));
     }
 }
@@ -207,19 +207,19 @@ class SACFromWellKnownFileTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->originalHome = getenv('HOME');
+        $this->originalHome = array_key_exists('HOME', $_ENV) ? $_ENV['HOME'] : false;
     }
 
     protected function tearDown(): void
     {
-        if ($this->originalHome != getenv('HOME')) {
-            putenv('HOME=' . $this->originalHome);
+        if ($this->originalHome != array_key_exists('HOME', $_ENV) ? $_ENV['HOME'] : false) {
+            $_ENV['HOME'] = $this->originalHome;
         }
     }
 
     public function testIsNullIfFileDoesNotExist()
     {
-        putenv('HOME=' . __DIR__ . '/../not_exists_fixtures');
+        $_ENV['HOME'] = __DIR__ . '/../not_exists_fixtures';
         $this->assertNull(
             ServiceAccountCredentials::fromWellKnownFile()
         );
@@ -227,7 +227,7 @@ class SACFromWellKnownFileTest extends TestCase
 
     public function testSucceedIfFileIsPresent()
     {
-        putenv('HOME=' . __DIR__ . '/../fixtures');
+        $_ENV['HOME'] = __DIR__ . '/../fixtures';
         $this->assertNotNull(
             ApplicationDefaultCredentials::getCredentials('a scope')
         );
@@ -784,7 +784,7 @@ class SACJwtAccessComboTest extends TestCase
     public function testJwtAccessFromApplicationDefault()
     {
         $keyFile = __DIR__ . '/../fixtures3/service_account_credentials.json';
-        putenv(ServiceAccountCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[ServiceAccountCredentials::ENV_VAR] = $keyFile;
         $creds = ApplicationDefaultCredentials::getCredentials(
             null, // $scope
             null, // $httpHandler

--- a/tests/Credentials/UserRefreshCredentialsTest.php
+++ b/tests/Credentials/UserRefreshCredentialsTest.php
@@ -149,7 +149,7 @@ class URCFromEnvTest extends TestCase
 {
     protected function tearDown(): void
     {
-        putenv(UserRefreshCredentials::ENV_VAR);  // removes it from
+        unset($_ENV[UserRefreshCredentials::ENV_VAR]);  // removes environment variable
     }
 
     public function testIsNullIfEnvVarIsNotSet()
@@ -161,14 +161,14 @@ class URCFromEnvTest extends TestCase
     {
         $this->expectException(DomainException::class);
         $keyFile = __DIR__ . '/../fixtures/does-not-exist-private.json';
-        putenv(UserRefreshCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[UserRefreshCredentials::ENV_VAR] = $keyFile;
         UserRefreshCredentials::fromEnv('a scope');
     }
 
     public function testSucceedIfFileExists()
     {
         $keyFile = __DIR__ . '/../fixtures2/private.json';
-        putenv(UserRefreshCredentials::ENV_VAR . '=' . $keyFile);
+        $_ENV[UserRefreshCredentials::ENV_VAR] = $keyFile;
         $this->assertNotNull(ApplicationDefaultCredentials::getCredentials('a scope'));
     }
 }
@@ -179,19 +179,19 @@ class URCFromWellKnownFileTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->originalHome = getenv('HOME');
+        $this->originalHome = array_key_exists('HOME', $_ENV) ? $_ENV['HOME'] : false;
     }
 
     protected function tearDown(): void
     {
-        if ($this->originalHome != getenv('HOME')) {
-            putenv('HOME=' . $this->originalHome);
+        if ($this->originalHome != array_key_exists('HOME', $_ENV) ? $_ENV['HOME'] : false) {
+            $_ENV['HOME'] = $this->originalHome;
         }
     }
 
     public function testIsNullIfFileDoesNotExist()
     {
-        putenv('HOME=' . __DIR__ . '/../not_exist_fixtures');
+        $_ENV['HOME'] = __DIR__ . '/../not_exist_fixtures';
         $this->assertNull(
             UserRefreshCredentials::fromWellKnownFile('a scope')
         );
@@ -199,7 +199,7 @@ class URCFromWellKnownFileTest extends TestCase
 
     public function testSucceedIfFileIsPresent()
     {
-        putenv('HOME=' . __DIR__ . '/../fixtures2');
+        $_ENV['HOME'] = __DIR__ . '/../fixtures2';
         $this->assertNotNull(
             ApplicationDefaultCredentials::getCredentials('a scope')
         );

--- a/tests/CredentialsLoaderTest.php
+++ b/tests/CredentialsLoaderTest.php
@@ -35,7 +35,7 @@ class CredentialsLoaderTest extends TestCase
     /** @runInSeparateProcess */
     public function testGetDefaultClientCertSource()
     {
-        putenv('HOME=' . __DIR__ . '/fixtures4/valid');
+        $_ENV['HOME'] = __DIR__ . '/fixtures4/valid';
 
         $callback = CredentialsLoader::getDefaultClientCertSource();
         $this->assertNotNull($callback);
@@ -47,7 +47,7 @@ class CredentialsLoaderTest extends TestCase
     /** @runInSeparateProcess */
     public function testNonExistantDefaultClientCertSource()
     {
-        putenv('HOME=');
+        $_ENV['HOME'] = '';
 
         $callback = CredentialsLoader::getDefaultClientCertSource();
         $this->assertNull($callback);
@@ -61,7 +61,7 @@ class CredentialsLoaderTest extends TestCase
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Invalid client cert source JSON');
 
-        putenv('HOME=' . __DIR__ . '/fixtures4/invalidjson');
+        $_ENV['HOME'] = __DIR__ . '/fixtures4/invalidjson';
 
         CredentialsLoader::getDefaultClientCertSource();
     }
@@ -74,7 +74,7 @@ class CredentialsLoaderTest extends TestCase
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('cert source requires "cert_provider_command"');
 
-        putenv('HOME=' . __DIR__ . '/fixtures4/invalidkey');
+        $_ENV['HOME'] = __DIR__ . '/fixtures4/invalidkey';
 
         CredentialsLoader::getDefaultClientCertSource();
     }
@@ -87,7 +87,7 @@ class CredentialsLoaderTest extends TestCase
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('cert source expects "cert_provider_command" to be an array');
 
-        putenv('HOME=' . __DIR__ . '/fixtures4/invalidvalue');
+        $_ENV['HOME'] = __DIR__ . '/fixtures4/invalidvalue';
 
         CredentialsLoader::getDefaultClientCertSource();
     }
@@ -115,7 +115,7 @@ class CredentialsLoaderTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('"cert_provider_command" failed with a nonzero exit code');
 
-        putenv('HOME=' . __DIR__ . '/fixtures4/invalidcmd');
+        $_ENV['HOME'] = __DIR__ . '/fixtures4/invalidcmd';
 
         $callback = CredentialsLoader::getDefaultClientCertSource();
 
@@ -130,7 +130,7 @@ class CredentialsLoaderTest extends TestCase
      */
     public function testShouldLoadClientCertSourceInvalidValueIsFalse()
     {
-        putenv(CredentialsLoader::MTLS_CERT_ENV_VAR . '=foo');
+        $_ENV[CredentialsLoader::MTLS_CERT_ENV_VAR] = 'foo';
 
         $this->assertFalse(CredentialsLoader::shouldLoadClientCertSource());
     }
@@ -140,7 +140,7 @@ class CredentialsLoaderTest extends TestCase
      */
     public function testShouldLoadClientCertSourceDefaultValueIsFalse()
     {
-        putenv(CredentialsLoader::MTLS_CERT_ENV_VAR);
+        unset($_ENV[CredentialsLoader::MTLS_CERT_ENV_VAR]);
 
         $this->assertFalse(CredentialsLoader::shouldLoadClientCertSource());
     }
@@ -150,7 +150,7 @@ class CredentialsLoaderTest extends TestCase
      */
     public function testShouldLoadClientCertSourceIsTrue()
     {
-        putenv(CredentialsLoader::MTLS_CERT_ENV_VAR . '=true');
+        $_ENV[CredentialsLoader::MTLS_CERT_ENV_VAR] = 'true';
 
         $this->assertTrue(CredentialsLoader::shouldLoadClientCertSource());
     }


### PR DESCRIPTION
The current version of google auth library php uses getenv/putenv to read and set environment variables in php. But the  function putenv is not threadsafe, which made libraries (Dotenv https://github.com/symfony/dotenv/blob/6.2/Dotenv.php#L61 and phpdotenv https://github.com/vlucas/phpdotenv#putenv-and-getenv) to disable putenv support by default. Frameworks like symfony (deprecated in 4.3 https://github.com/symfony/symfony/pull/31062 and removed in 5.0) and also in laravel there was a similiar solution to not use it anymore directly (https://github.com/vlucas/phpdotenv/issues/76).

Thus here is a pull request to change all the ocurences of:

- `getenv($variable)` to `array_key_exists($variable, $_ENV) ? $_ENV[$variable] : false`
- `putenv($variable)` to `unset($_ENV[$variable])`
- `putenv($variable . "=")` to `$_ENV[$variable]=''`
- `putenv($variable . "=" . $value)` to `$_ENV[$variable]=$value`

Threads about this:

- https://bugs.php.net/bug.php?id=74143 (putenv does not work if fast cgi sets the variable!)
- https://github.com/symfony/symfony/pull/31062
- https://github.com/vlucas/phpdotenv/issues/76
- https://github.com/laravel/framework/issues/7354 
- https://github.com/laravel/framework/commit/866a8cfc58430830069bd24feacf2d81e99385a2
- https://github.com/silverstripe/silverstripe-framework/pull/7484
- https://github.com/laravel/framework/issues/27949

