### PR TITLE
feat: add getFetcher to FetchAuthTokenCache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ "7.1", "7.2", "7.3", "7.4", "8.0", "8.1" ]
+                php: [ "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2" ]
         name: PHP ${{matrix.php }} Unit Test
         steps:
             - uses: actions/checkout@v3

--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -60,6 +60,11 @@ class FetchAuthTokenCache implements
         ], (array) $cacheConfig);
     }
 
+    public function getFetcher()
+    {
+        return $this->fetcher;
+    }
+
     /**
      * Implements FetchAuthTokenInterface#fetchAuthToken.
      *

--- a/tests/FetchAuthTokenCacheTest.php
+++ b/tests/FetchAuthTokenCacheTest.php
@@ -599,4 +599,17 @@ class FetchAuthTokenCacheTest extends BaseTest
 
         $fetcher->getProjectId();
     }
+
+    public function testGetFetcher()
+    {
+        $mockFetcher = $this->prophesize('Google\Auth\FetchAuthTokenInterface')
+            ->reveal();
+        $fetcher = new FetchAuthTokenCache(
+            $mockFetcher,
+            [],
+            $this->mockCache->reveal()
+        );
+
+        $this->assertSame($mockFetcher, $fetcher->getFetcher());
+    }
 }


### PR DESCRIPTION
This is needed for https://github.com/googleapis/gax-php/pull/441

**Note**: We will also need to cherry-pick this commit into [v1.19.0](https://github.com/googleapis/google-auth-library-php/releases/tag/v1.19.0) and tag `v1.19.1` as well, to provide compatibility in GAX for PHP 7.0.