### PR TITLE
feat: accessing granted scopes 

### DIFF
--- a/src/Credentials/UserRefreshCredentials.php
+++ b/src/Credentials/UserRefreshCredentials.php
@@ -139,4 +139,14 @@ class UserRefreshCredentials extends CredentialsLoader implements GetQuotaProjec
     {
         return $this->quotaProject;
     }
+
+    /**
+     * Get the granted scopes (if they exist) for the last fetched token.
+     *
+     * @return string|null
+     */
+    public function getGrantedScope()
+    {
+        return $this->auth->getGrantedScope();
+    }
 }

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -216,6 +216,13 @@ class OAuth2 implements FetchAuthTokenInterface
     private $idToken;
 
     /**
+     * The scopes granted to the current access token
+     *
+     * @var string
+     */
+    private $grantedScope;
+
+    /**
      * The lifetime in seconds of the current access token.
      *
      * @var ?int
@@ -544,6 +551,9 @@ class OAuth2 implements FetchAuthTokenInterface
         $response = $httpHandler($this->generateCredentialsRequest());
         $credentials = $this->parseTokenResponse($response);
         $this->updateToken($credentials);
+        if (isset($credentials['scope'])) {
+            $this->setGrantedScope($credentials['scope']);
+        }
 
         return $credentials;
     }
@@ -640,6 +650,7 @@ class OAuth2 implements FetchAuthTokenInterface
             'expires_in' => null,
             'expires_at' => null,
             'issued_at' => null,
+            'scope' => null,
         ], $config);
 
         $this->setExpiresAt($opts['expires_at']);
@@ -652,6 +663,7 @@ class OAuth2 implements FetchAuthTokenInterface
 
         $this->setAccessToken($opts['access_token']);
         $this->setIdToken($opts['id_token']);
+
         // The refresh token should only be updated if a value is explicitly
         // passed in, as some access token responses do not include a refresh
         // token.
@@ -1333,6 +1345,27 @@ class OAuth2 implements FetchAuthTokenInterface
     public function setIdToken($idToken)
     {
         $this->idToken = $idToken;
+    }
+
+    /**
+     * Get the granted scopes (if they exist) for the last fetched token.
+     *
+     * @return string|null
+     */
+    public function getGrantedScope()
+    {
+        return $this->grantedScope;
+    }
+
+    /**
+     * Sets the current ID token.
+     *
+     * @param string $grantedScope
+     * @return void
+     */
+    public function setGrantedScope($grantedScope)
+    {
+        $this->grantedScope = $grantedScope;
     }
 
     /**

--- a/tests/Credentials/UserRefreshCredentialsTest.php
+++ b/tests/Credentials/UserRefreshCredentialsTest.php
@@ -253,6 +253,20 @@ class URCFetchAuthTokenTest extends TestCase
         $tokens = $sa->fetchAuthToken($httpHandler);
         $this->assertEquals($testJson, $tokens);
     }
+
+    public function testGetGrantedScope()
+    {
+        $responseJson = json_encode(['scope' => 'scope/1 scope/2']);
+        $httpHandler = getHandler([
+            buildResponse(200, [], Utils::streamFor($responseJson)),
+        ]);
+        $sa = new UserRefreshCredentials(
+            '',
+            createURCTestJson()
+        );
+        $sa->fetchAuthToken($httpHandler);
+        $this->assertEquals('scope/1 scope/2', $sa->getGrantedScope());
+    }
 }
 
 class URCGetQuotaProjectTest extends TestCase

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -756,6 +756,7 @@ class OAuth2FetchAuthTokenTest extends TestCase
             'access_token' => 'an_access_token',
             'id_token' => 'an_id_token',
             'refresh_token' => 'a_refresh_token',
+            'scope' => 'scope1 scope2',
         ];
         $json = json_encode($wanted_updates);
         $httpHandler = getHandler([
@@ -775,6 +776,7 @@ class OAuth2FetchAuthTokenTest extends TestCase
         $this->assertEquals('an_access_token', $o->getAccessToken());
         $this->assertEquals('an_id_token', $o->getIdToken());
         $this->assertEquals('a_refresh_token', $o->getRefreshToken());
+        $this->assertEquals('scope1 scope2', $o->getGrantedScope());
     }
 
     public function testUpdatesTokenFieldsOnFetchMissingRefreshToken()


### PR DESCRIPTION
b/253077796

Adds support for accessing granted scopes on the OAuth2 service class

**Q: Does this need to be accessible by the end user?**
 - Yes

**Q: If so, how will this be accessible by the end user?**
 - Exposing a method such as `getGrantedScopes` on the `Credentials` object is sufficient for this library.

**Q: How is this different from the existing `getScopes` method?**
 - It wouldn't be any different for the other credentials types, only for `OAuth2` and `UserRefreshCredentials`, because they get information back from the API