### PR TITLE
chore: github workflows marked readOnly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,8 @@ on:
             - main
         tags:
             - "*"
-
+permissions:
+  contents: read
 jobs:
     docs:
         name: "Generate Project Documentation"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,9 @@ on:
   push:
     branches: [ main ]
   pull_request:
-
+  
+permissions:
+  contents: read
 jobs:
     test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Following up on Step Security's suggestions to restrict permissions for `GITHUB_TOKEN`.