### PR TITLE
chore(tests): migrate phpunit configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php"
-         colors="true"
-         convertWarningsToExceptions="false"
-         convertNoticesToExceptions="false"
-         convertErrorsToExceptions="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" convertWarningsToExceptions="false" convertNoticesToExceptions="false" convertErrorsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix="Interface.php">src/</directory>
+    </exclude>
+  </coverage>
   <testsuites>
     <testsuite name="google-auth-tests">
       <directory suffix="Test.php">tests</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-      <exclude>
-        <directory suffix="Interface.php">src/</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>


### PR DESCRIPTION
PhpUnit throws the following error / suggestion, hence upgrading all it's configs by using `--migrate-configuration`:
```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```