### PR TITLE
chore: fix PHP Deprecation warnings in tests

### DIFF
--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -36,10 +36,10 @@ class AccessTokenTest extends TestCase
 
     private $cache;
     private $payload;
-
     private $token;
     private $publicKey;
     private $allowedAlgs;
+    private $jwt;
 
     public function setUp(): void
     {


### PR DESCRIPTION
In [current test logs](https://github.com/googleapis/google-auth-library-php/actions/runs/4865928966/jobs/8676865153), we get logs like this `Deprecated: Creation of dynamic property Google\Auth\Tests\AccessTokenTest::$jwt is deprecated in /Users/vishwarajanand/github/google-auth-library-php/tests/AccessTokenTest.php on line 47`

With this change, we want to remove them.