### PR TITLE
feat: add pkce support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ composer.lock
 .cache
 .docs
 .gitmodules
+.phpunit.result.cache
 
 # IntelliJ
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ composer.lock
 .cache
 .docs
 .gitmodules
-.phpunit.result.cache
 
 # IntelliJ
 .idea

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -269,6 +269,16 @@ class OAuth2 implements FetchAuthTokenInterface
     private $additionalClaims;
 
     /**
+     * The code verifier for PKCE for OAuth 2.0. When set, the authorization
+     * URI will contain the Code Challenge and Code Challenge Method querystring
+     * parameters, and the token URI will contain the Code Verifier parameter.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc7636
+     * @var ?string
+     */
+    private $codeVerifier;
+
+    /**
      * Create a new OAuthCredentials.
      *
      * The configuration array accepts various options
@@ -357,6 +367,7 @@ class OAuth2 implements FetchAuthTokenInterface
             'signingAlgorithm' => null,
             'scope' => null,
             'additionalClaims' => [],
+            'codeVerifier' => null,
         ], $config);
 
         $this->setAuthorizationUri($opts['authorizationUri']);
@@ -377,6 +388,7 @@ class OAuth2 implements FetchAuthTokenInterface
         $this->setScope($opts['scope']);
         $this->setExtensionParams($opts['extensionParams']);
         $this->setAdditionalClaims($opts['additionalClaims']);
+        $this->setCodeVerifier($opts['codeVerifier']);
         $this->updateToken($opts);
     }
 
@@ -496,6 +508,9 @@ class OAuth2 implements FetchAuthTokenInterface
             case 'authorization_code':
                 $params['code'] = $this->getCode();
                 $params['redirect_uri'] = $this->getRedirectUri();
+                if ($this->codeVerifier) {
+                    $params['code_verifier'] = $this->codeVerifier;
+                }
                 $this->addClientCredentials($params);
                 break;
             case 'password':
@@ -675,7 +690,7 @@ class OAuth2 implements FetchAuthTokenInterface
     /**
      * Builds the authorization Uri that the user should be redirected to.
      *
-     * @param array<mixed> $config configuration options that customize the return url
+     * @param array<mixed> Configuration options that customize the return url.
      * @return UriInterface the authorization Url.
      * @throws InvalidArgumentException
      */
@@ -710,6 +725,13 @@ class OAuth2 implements FetchAuthTokenInterface
                 'prompt and approval_prompt are mutually exclusive'
             );
         }
+        if ($this->codeVerifier) {
+            // throw new \Exception('here');
+            $params['code_challenge'] = $this->getCodeChallenge(
+                $params['code_verifier'] ?? $this->codeVerifier
+            );
+            $params['code_challenge_method'] = $this->getCodeChallengeMethod();
+        }
 
         // Construct the uri object; return it if it is valid.
         $result = clone $this->authorizationUri;
@@ -726,6 +748,57 @@ class OAuth2 implements FetchAuthTokenInterface
         }
 
         return $result;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCodeVerifier(): ?string
+    {
+        return $this->codeVerifier;
+    }
+
+    /**
+     * A cryptographically random string that is used to correlate the
+     * authorization request to the token request.
+     *
+     * The code verifier for PKCE for OAuth 2.0. When set, the authorization
+     * URI will contain the Code Challenge and Code Challenge Method querystring
+     * parameters, and the token URI will contain the Code Verifier parameter.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc7636
+     *
+     * @param string $codeVerifier
+     */
+    public function setCodeVerifier(?string $codeVerifier): void
+    {
+        $this->codeVerifier = $codeVerifier;
+    }
+
+    public function generateCodeVerifier(): string
+    {
+        return $this->generateRandomString(128);
+    }
+
+    private function getCodeChallenge(string $randomString): string
+    {
+        return rtrim(strtr(base64_encode(hash('sha256', $randomString, true)), '+/', '-_'), '=');
+    }
+
+    private function getCodeChallengeMethod(): string
+    {
+        return 'S256';
+    }
+
+    private function generateRandomString(int $length): string
+    {
+        $validChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
+        $validCharsLen = strlen($validChars);
+        $str = '';
+        while ($i++ < $length) {
+            $str .= $validChars[random_int(0, $validCharsLen - 1)];
+        }
+        return $str;
     }
 
     /**

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -690,7 +690,7 @@ class OAuth2 implements FetchAuthTokenInterface
     /**
      * Builds the authorization Uri that the user should be redirected to.
      *
-     * @param array<mixed> Configuration options that customize the return url.
+     * @param array<mixed> $config Configuration options that customize the return url.
      * @return UriInterface the authorization Url.
      * @throws InvalidArgumentException
      */
@@ -792,9 +792,10 @@ class OAuth2 implements FetchAuthTokenInterface
 
     private function generateRandomString(int $length): string
     {
-        $validChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
+        $validChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~';
         $validCharsLen = strlen($validChars);
         $str = '';
+        $i = 0;
         while ($i++ < $length) {
             $str .= $validChars[random_int(0, $validCharsLen - 1)];
         }

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -690,7 +690,7 @@ class OAuth2 implements FetchAuthTokenInterface
     /**
      * Builds the authorization Uri that the user should be redirected to.
      *
-     * @param array<mixed> $config Configuration options that customize the return url.
+     * @param array<mixed> $config configuration options that customize the return url.
      * @return UriInterface the authorization Url.
      * @throws InvalidArgumentException
      */
@@ -726,9 +726,7 @@ class OAuth2 implements FetchAuthTokenInterface
             );
         }
         if ($this->codeVerifier) {
-            $params['code_challenge'] = $this->getCodeChallenge(
-                $params['code_verifier'] ?? $this->codeVerifier
-            );
+            $params['code_challenge'] = $this->getCodeChallenge($this->codeVerifier);
             $params['code_challenge_method'] = $this->getCodeChallengeMethod();
         }
 

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -726,7 +726,6 @@ class OAuth2 implements FetchAuthTokenInterface
             );
         }
         if ($this->codeVerifier) {
-            // throw new \Exception('here');
             $params['code_challenge'] = $this->getCodeChallenge(
                 $params['code_verifier'] ?? $this->codeVerifier
             );

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -778,11 +778,13 @@ class OAuth2 implements FetchAuthTokenInterface
      * determined using random_int, hashed using "hash" and sha256, and base64
      * encoded.
      *
+     * When this method is called, the code verifier is set on the object.
+     *
      * @return string
      */
     public function generateCodeVerifier(): string
     {
-        return $this->generateRandomString(128);
+        return $this->codeVerifier = $this->generateRandomString(128);
     }
 
     private function getCodeChallenge(string $randomString): string

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -774,6 +774,14 @@ class OAuth2 implements FetchAuthTokenInterface
         $this->codeVerifier = $codeVerifier;
     }
 
+    /**
+     * Generates a random 128-character string for the "code_verifier" parameter
+     * in PKCE for OAuth 2.0. This is a cryptographically random string that is
+     * determined using random_int, hashed using "hash" and sha256, and base64
+     * encoded.
+     *
+     * @return string
+     */
     public function generateCodeVerifier(): string
     {
         return $this->generateRandomString(128);

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -748,7 +748,7 @@ class OAuth2 implements FetchAuthTokenInterface
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCodeVerifier(): ?string
     {
@@ -765,7 +765,7 @@ class OAuth2 implements FetchAuthTokenInterface
      *
      * @see https://datatracker.ietf.org/doc/html/rfc7636
      *
-     * @param string $codeVerifier
+     * @param string|null $codeVerifier
      */
     public function setCodeVerifier(?string $codeVerifier): void
     {

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -175,6 +175,14 @@ class OAuth2AuthorizationUriTest extends TestCase
         $this->assertEquals('S256', $q['code_challenge_method']);
     }
 
+    public function testGenerateCodeVerifier()
+    {
+        $o = new OAuth2($this->minimal);
+        $codeVerifier = $o->generateCodeVerifier();
+        $this->assertEquals(128, strlen($codeVerifier));
+        $this->assertNotEquals($codeVerifier, $o->generateCodeVerifier());
+    }
+
     public function testIncludesTheScope()
     {
         $with_strings = array_merge($this->minimal, ['scope' => 'scope1 scope2']);
@@ -704,7 +712,7 @@ class OAuth2GenerateAccessTokenRequestTest extends TestCase
         $req = $o->generateCredentialsRequest();
         $fields = Query::parse((string) $req->getBody());
         $this->assertArrayHasKey('code_verifier', $fields);
-        $this->assertEquals($codeVerifier, $fields['code_verifier']);;
+        $this->assertEquals($codeVerifier, $fields['code_verifier']);
 
         // test in settter
         $o = new OAuth2($this->tokenRequestMinimal);
@@ -713,7 +721,7 @@ class OAuth2GenerateAccessTokenRequestTest extends TestCase
         $req = $o->generateCredentialsRequest();
         $q = Query::parse((string) $req->getBody());
         $this->assertArrayHasKey('code_verifier', $q);
-        $this->assertEquals($codeVerifier, $q['code_verifier']);;
+        $this->assertEquals($codeVerifier, $q['code_verifier']);
     }
 }
 

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -180,7 +180,12 @@ class OAuth2AuthorizationUriTest extends TestCase
         $o = new OAuth2($this->minimal);
         $codeVerifier = $o->generateCodeVerifier();
         $this->assertEquals(128, strlen($codeVerifier));
+        // The generated code verifier is set on the object
+        $this->assertEquals($o->getCodeVerifier(), $codeVerifier);
+        // When it's called again, it generates a new one
         $this->assertNotEquals($codeVerifier, $o->generateCodeVerifier());
+        // The new code verifier is set on the object
+        $this->assertNotEquals($codeVerifier, $o->getCodeVerifier());
     }
 
     public function testIncludesTheScope()

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -151,6 +151,30 @@ class OAuth2AuthorizationUriTest extends TestCase
         $this->assertEquals('o_state', $q['state']);
     }
 
+    public function testAuthorizationUriWithCodeVerifier()
+    {
+        $codeVerifier = 'my_code_verifier';
+        $expectedCodeChallenge = 'DLIjHQaEUYlb3dD1s35ERX1uDg0eu3_9ggFsQayed5c';
+
+        // test in constructor
+        $config = array_merge($this->minimal, ['codeVerifier' => $codeVerifier]);
+        $o = new OAuth2($config);
+        $q = Query::parse($o->buildFullAuthorizationUri()->getQuery());
+        $this->assertArrayNotHasKey('code_verifier', $q);
+        $this->assertArrayHasKey('code_challenge', $q);
+        $this->assertEquals($expectedCodeChallenge, $q['code_challenge']);
+        $this->assertEquals('S256', $q['code_challenge_method']);
+
+        // test in settter
+        $o = new OAuth2($this->minimal);
+        $o->setCodeVerifier($codeVerifier);
+        $q = Query::parse($o->buildFullAuthorizationUri()->getQuery());
+        $this->assertArrayNotHasKey('code_verifier', $q);
+        $this->assertArrayHasKey('code_challenge', $q);
+        $this->assertEquals($expectedCodeChallenge, $q['code_challenge']);
+        $this->assertEquals('S256', $q['code_challenge_method']);
+    }
+
     public function testIncludesTheScope()
     {
         $with_strings = array_merge($this->minimal, ['scope' => 'scope1 scope2']);
@@ -665,6 +689,31 @@ class OAuth2GenerateAccessTokenRequestTest extends TestCase
         $fields = Query::parse((string)$req->getBody());
         $this->assertEquals('my_value', $fields['my_param']);
         $this->assertEquals('urn:my_test_grant_type', $fields['grant_type']);
+    }
+
+    public function testTokenUriWithCodeVerifier()
+    {
+        $codeVerifier = 'my_code_verifier';
+
+        // test in constructor
+        $config = array_merge($this->tokenRequestMinimal, [
+            'codeVerifier' => $codeVerifier,
+        ]);
+        $o = new OAuth2($config);
+        $o->setCode('abc123');
+        $req = $o->generateCredentialsRequest();
+        $fields = Query::parse((string) $req->getBody());
+        $this->assertArrayHasKey('code_verifier', $fields);
+        $this->assertEquals($codeVerifier, $fields['code_verifier']);;
+
+        // test in settter
+        $o = new OAuth2($this->tokenRequestMinimal);
+        $o->setCode('abc123');
+        $o->setCodeVerifier($codeVerifier);
+        $req = $o->generateCredentialsRequest();
+        $q = Query::parse((string) $req->getBody());
+        $this->assertArrayHasKey('code_verifier', $q);
+        $this->assertEquals($codeVerifier, $q['code_verifier']);;
     }
 }
 


### PR DESCRIPTION
In order to support [PKCE for OAuth2](https://datatracker.ietf.org/doc/html/rfc7636), adds the following **public** methods:

 - `OAuth2::generateCodeVerifier(): string`
 - `OAuth2::setCodeVerifier(string $codeVerifier): void`
 - `OAuth2::getCodeVerifier(): string`

**Usage**

_Authorization Request_
```php
$auth = new OAuth2(['client_id' => $clientId, 'client_secret' => $clientSecret]);

// Example of how a developer might save the code verifier in a stateless application
// NOTE: calling "generateCodeVerifier" will enable PKCE
$_SESSION['code_verifier'] = $auth->generateCodeVerifier();

// The authorization URI will include "code_challenge" and "code_challenge_method"
// querystring parameters if a code verifier is supplied
// (e.g. https://example.com?code_challenge=[base64 code_verifier]&code_challenge_method=S256)
redirect($auth->buildFullAuthorizationUri());
```
_Token Request_
```php
$auth = new OAuth2(['client_id' => $clientId, 'client_secret' => $clientSecret]);

// example of how a developer might retrieve the code verifier in a stateless application
$codeVerifier = $_SESSION['code_verifier'];

// The token URI will include "code_verifier" in the request body if a code verifier is supplied
$auth->setCodeVerifier($codeVerifier);
$token = $auth->fetchAuthToken();
```

See b/270198724