### PR TITLE
chore: refactor oauth2 tests

### DIFF
--- a/src/Credentials/ImpersonatedServiceAccountCredentials.php
+++ b/src/Credentials/ImpersonatedServiceAccountCredentials.php
@@ -37,13 +37,13 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
     protected $sourceCredentials;
 
     /**
-     * Instantiate an instance of ImpersonatedServiceAccountCredentials from a credentials file that has be created with
-     * the --impersonated-service-account flag.
+     * Instantiate an instance of ImpersonatedServiceAccountCredentials from a credentials file that
+     * has be created with the --impersonated-service-account flag.
      *
-     * @param string|string[] $scope the scope of the access request, expressed
-     *   either as an Array or as a space-delimited String.
+     * @param string|string[]     $scope   The scope of the access request, expressed either as an
+     *                                     array or as a space-delimited string.
      * @param string|array<mixed> $jsonKey JSON credential file path or JSON credentials
-     *   as an associative array
+     *                                     as an associative array.
      */
     public function __construct(
         $scope,
@@ -59,24 +59,34 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
             }
         }
         if (!array_key_exists('service_account_impersonation_url', $jsonKey)) {
-            throw new \LogicException('json key is missing the service_account_impersonation_url field');
+            throw new \LogicException(
+                'json key is missing the service_account_impersonation_url field'
+            );
         }
         if (!array_key_exists('source_credentials', $jsonKey)) {
             throw new \LogicException('json key is missing the source_credentials field');
         }
 
-        $this->impersonatedServiceAccountName = $this->getImpersonatedServiceAccountNameFromUrl($jsonKey['service_account_impersonation_url']);
+        $this->impersonatedServiceAccountName = $this->getImpersonatedServiceAccountNameFromUrl(
+            $jsonKey['service_account_impersonation_url']
+        );
 
-        $this->sourceCredentials = new UserRefreshCredentials($scope, $jsonKey['source_credentials']);
+        $this->sourceCredentials = new UserRefreshCredentials(
+            $scope,
+            $jsonKey['source_credentials']
+        );
     }
 
     /**
-     * Helper function for extracting the Server Account Name from the URL saved in the account credentials file
-     * @param $serviceAccountImpersonationUrl string URL from the 'service_account_impersonation_url' field
+     * Helper function for extracting the Server Account Name from the URL saved in the account
+     * credentials file.
+     *
+     * @param $serviceAccountImpersonationUrl string URL from "service_account_impersonation_url"
      * @return string Service account email or ID.
      */
-    private function getImpersonatedServiceAccountNameFromUrl(string $serviceAccountImpersonationUrl)
-    {
+    private function getImpersonatedServiceAccountNameFromUrl(
+        string $serviceAccountImpersonationUrl
+    ): string {
         $fields = explode('/', $serviceAccountImpersonationUrl);
         $lastField = end($fields);
         $splitter = explode(':', $lastField);

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -70,6 +70,9 @@ class OAuth2Test extends TestCase
         'clientId' => 'myaccount.on.host.issuer.com',
     ];
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testIsNullIfAuthorizationUriIsNull()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -78,6 +81,9 @@ class OAuth2Test extends TestCase
         $this->assertNull($o->buildFullAuthorizationUri());
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testRequiresTheClientId()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -89,6 +95,9 @@ class OAuth2Test extends TestCase
         $o->buildFullAuthorizationUri();
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testRequiresTheRedirectUri()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -100,6 +109,9 @@ class OAuth2Test extends TestCase
         $o->buildFullAuthorizationUri();
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testCannotHavePromptAndApprovalPrompt()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -114,6 +126,9 @@ class OAuth2Test extends TestCase
         ]);
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testCannotHaveInsecureAuthorizationUri()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -126,6 +141,9 @@ class OAuth2Test extends TestCase
         $o->buildFullAuthorizationUri();
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testCannotHaveRelativeRedirectUri()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -138,6 +156,9 @@ class OAuth2Test extends TestCase
         $o->buildFullAuthorizationUri();
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testAudOrScopeIsRequiredForJwt()
     {
         $this->expectException(DomainException::class);
@@ -149,6 +170,9 @@ class OAuth2Test extends TestCase
         $o->toJwt();
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testHasDefaultXXXTypeParams()
     {
         $o = new OAuth2($this->minimal);
@@ -157,6 +181,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('offline', $q['access_type']);
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testCanBeUrlObject()
     {
         $config = array_merge($this->minimal, [
@@ -166,6 +193,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('/uri', $o->buildFullAuthorizationUri()->getPath());
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testCanOverrideParams()
     {
         $overrides = [
@@ -185,6 +215,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('o_state', $q['state']);
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testAuthorizationUriWithCodeVerifier()
     {
         $codeVerifier = 'my_code_verifier';
@@ -209,6 +242,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('S256', $q['code_challenge_method']);
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testGenerateCodeVerifier()
     {
         $o = new OAuth2($this->minimal);
@@ -222,6 +258,9 @@ class OAuth2Test extends TestCase
         $this->assertNotEquals($codeVerifier, $o->getCodeVerifier());
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testIncludesTheScope()
     {
         $with_strings = array_merge($this->minimal, ['scope' => 'scope1 scope2']);
@@ -237,6 +276,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('scope1 scope2', $q['scope']);
     }
 
+    /**
+     * @group oauth2-authorization-uri
+     */
     public function testRedirectUriPostmessageIsAllowed()
     {
         $o = new OAuth2([
@@ -252,12 +294,18 @@ class OAuth2Test extends TestCase
         $this->assertEquals('postmessage', $query['redirect_uri']);
     }
 
+    /**
+     * @group oauth2-grant-type
+     */
     public function testReturnsNullIfCannotBeInferred()
     {
         $o = new OAuth2($this->minimal);
         $this->assertNull($o->getGrantType());
     }
 
+    /**
+     * @group oauth2-grant-type
+     */
     public function testInfersAuthorizationCode()
     {
         $o = new OAuth2($this->minimal);
@@ -265,6 +313,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('authorization_code', $o->getGrantType());
     }
 
+    /**
+     * @group oauth2-grant-type
+     */
     public function testInfersRefreshToken()
     {
         $o = new OAuth2($this->minimal);
@@ -272,6 +323,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('refresh_token', $o->getGrantType());
     }
 
+    /**
+     * @group oauth2-grant-type
+     */
     public function testInfersPassword()
     {
         $o = new OAuth2($this->minimal);
@@ -280,6 +334,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('password', $o->getGrantType());
     }
 
+    /**
+     * @group oauth2-grant-type
+     */
     public function testInfersJwtBearer()
     {
         $o = new OAuth2($this->minimal);
@@ -291,6 +348,9 @@ class OAuth2Test extends TestCase
         );
     }
 
+    /**
+     * @group oauth2-grant-type
+     */
     public function testSetsKnownTypes()
     {
         $o = new OAuth2($this->minimal);
@@ -300,6 +360,9 @@ class OAuth2Test extends TestCase
         }
     }
 
+    /**
+     * @group oauth2-grant-type
+     */
     public function testSetsUrlAsGrantType()
     {
         $o = new OAuth2($this->minimal);
@@ -307,12 +370,18 @@ class OAuth2Test extends TestCase
         $this->assertEquals('http://a/grant/url', $o->getGrantType());
     }
 
+    /**
+     * @group oauth2-cache-key
+     */
     public function testIsNullWithNoScopesOrAudience()
     {
         $o = new OAuth2($this->minimal);
         $this->assertNull($o->getCacheKey());
     }
 
+    /**
+     * @group oauth2-cache-key
+     */
     public function testIsScopeIfSingleScope()
     {
         $o = new OAuth2($this->minimal);
@@ -320,6 +389,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('test/scope/1', $o->getCacheKey());
     }
 
+    /**
+     * @group oauth2-cache-key
+     */
     public function testIsAllScopesWhenScopeIsArray()
     {
         $o = new OAuth2($this->minimal);
@@ -327,6 +399,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('test/scope/1:test/scope/2', $o->getCacheKey());
     }
 
+    /**
+     * @group oauth2-cache-key
+     */
     public function testIsAudienceWhenScopeIsNull()
     {
         $aud = 'https://drive.googleapis.com';
@@ -335,24 +410,36 @@ class OAuth2Test extends TestCase
         $this->assertEquals($aud, $o->getCacheKey());
     }
 
+    /**
+     * @group oauth2-timing
+     */
     public function testIssuedAtDefaultsToNull()
     {
         $o = new OAuth2($this->minimal);
         $this->assertNull($o->getIssuedAt());
     }
 
+    /**
+     * @group oauth2-timing
+     */
     public function testExpiresAtDefaultsToNull()
     {
         $o = new OAuth2($this->minimal);
         $this->assertNull($o->getExpiresAt());
     }
 
+    /**
+     * @group oauth2-timing
+     */
     public function testExpiresInDefaultsToNull()
     {
         $o = new OAuth2($this->minimal);
         $this->assertNull($o->getExpiresIn());
     }
 
+    /**
+     * @group oauth2-timing
+     */
     public function testSettingExpiresInSetsIssuedAt()
     {
         $o = new OAuth2($this->minimal);
@@ -363,6 +450,9 @@ class OAuth2Test extends TestCase
         $this->assertNotNull($o->getIssuedAt());
     }
 
+    /**
+     * @group oauth2-timing
+     */
     public function testSettingExpiresInSetsExpireAt()
     {
         $o = new OAuth2($this->minimal);
@@ -373,12 +463,18 @@ class OAuth2Test extends TestCase
         $this->assertEquals($aShortWhile, $o->getExpiresAt() - $o->getIssuedAt());
     }
 
+    /**
+     * @group oauth2-timing
+     */
     public function testIsNotExpiredByDefault()
     {
         $o = new OAuth2($this->minimal);
         $this->assertFalse($o->isExpired());
     }
 
+    /**
+     * @group oauth2-timing
+     */
     public function testIsNotExpiredIfExpiresAtIsOld()
     {
         $o = new OAuth2($this->minimal);
@@ -386,6 +482,9 @@ class OAuth2Test extends TestCase
         $this->assertTrue($o->isExpired());
     }
 
+    /**
+     * @group oauth2-general
+     */
     public function testFailsOnUnknownSigningAlgorithm()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -394,6 +493,9 @@ class OAuth2Test extends TestCase
         $o->setSigningAlgorithm('this is definitely not an algorithm name');
     }
 
+    /**
+     * @group oauth2-general
+     */
     public function testAllowsKnownSigningAlgorithms()
     {
         $o = new OAuth2($this->minimal);
@@ -403,6 +505,9 @@ class OAuth2Test extends TestCase
         }
     }
 
+    /**
+     * @group oauth2-general
+     */
     public function testFailsOnRelativeRedirectUri()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -411,6 +516,9 @@ class OAuth2Test extends TestCase
         $o->setRedirectUri('/relative/url');
     }
 
+    /**
+     * @group oauth2-general
+     */
     public function testAllowsUrnRedirectUri()
     {
         $urn = 'urn:ietf:wg:oauth:2.0:oob';
@@ -419,6 +527,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals($urn, $o->getRedirectUri());
     }
 
+    /**
+     * @group oauth2-jwt
+     */
     public function testFailsWithMissingAudience()
     {
         $this->expectException(DomainException::class);
@@ -429,6 +540,9 @@ class OAuth2Test extends TestCase
         $o->toJwt();
     }
 
+    /**
+     * @group oauth2-jwt
+     */
     public function testFailsWithMissingIssuer()
     {
         $this->expectException(DomainException::class);
@@ -438,6 +552,9 @@ class OAuth2Test extends TestCase
         $o->toJwt();
     }
 
+    /**
+     * @group oauth2-jwt
+     */
     public function testCanHaveNoScope()
     {
         $testConfig = $this->signingMinimal;
@@ -447,6 +564,9 @@ class OAuth2Test extends TestCase
         $this->assertTrue(is_string($jwt));
     }
 
+    /**
+     * @group oauth2-jwt
+     */
     public function testFailsWithMissingSigningKey()
     {
         $this->expectException(DomainException::class);
@@ -457,6 +577,9 @@ class OAuth2Test extends TestCase
         $o->toJwt();
     }
 
+    /**
+     * @group oauth2-jwt
+     */
     public function testFailsWithMissingSigningAlgorithm()
     {
         $this->expectException(DomainException::class);
@@ -466,6 +589,9 @@ class OAuth2Test extends TestCase
         $o->toJwt();
     }
 
+    /**
+     * @group oauth2-jwt
+     */
     public function testCanHS256EncodeAValidPayloadWithSigningKeyId()
     {
         $testConfig = $this->signingMinimal;
@@ -483,6 +609,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals($roundTrip->scope, $testConfig['scope']);
     }
 
+    /**
+     * @group oauth2-jwt
+     */
     public function testFailDecodeWithoutSigningKeyId()
     {
         $testConfig = $this->signingMinimal;
@@ -507,6 +636,9 @@ class OAuth2Test extends TestCase
         $this->fail('Expected exception about problem with decode');
     }
 
+    /**
+     * @group oauth2-jwt
+     */
     public function testCanHS256EncodeAValidPayload()
     {
         $testConfig = $this->signingMinimal;
@@ -518,6 +650,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals($roundTrip->scope, $testConfig['scope']);
     }
 
+    /**
+     * @group oauth2-jwt
+     */
     public function testCanRS256EncodeAValidPayload()
     {
         $publicKey = file_get_contents(__DIR__ . '/fixtures' . '/public.pem');
@@ -533,6 +668,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals($roundTrip->scope, $testConfig['scope']);
     }
 
+    /**
+     * @group oauth2-jwt
+     */
     public function testCanHaveAdditionalClaims()
     {
         $publicKey = file_get_contents(__DIR__ . '/fixtures' . '/public.pem');
@@ -548,6 +686,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals($roundTrip->target_audience, $targetAud);
     }
 
+    /**
+     * @group oauth2-generate-access-token
+     */
     public function testFailsIfNoTokenCredentialUri()
     {
         $this->expectException(DomainException::class);
@@ -557,6 +698,9 @@ class OAuth2Test extends TestCase
         $o->generateCredentialsRequest();
     }
 
+    /**
+     * @group oauth2-generate-access-token
+     */
     public function testFailsIfAuthorizationCodeIsMissing()
     {
         $this->expectException(DomainException::class);
@@ -566,6 +710,9 @@ class OAuth2Test extends TestCase
         $o->generateCredentialsRequest();
     }
 
+    /**
+     * @group oauth2-generate-access-token
+     */
     public function testGeneratesAuthorizationCodeRequests()
     {
         $testConfig = $this->tokenRequestMinimal;
@@ -582,6 +729,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('an_auth_code', $fields['code']);
     }
 
+    /**
+     * @group oauth2-generate-access-token
+     */
     public function testGeneratesPasswordRequests()
     {
         $testConfig = $this->tokenRequestMinimal;
@@ -599,6 +749,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('a_username', $fields['username']);
     }
 
+    /**
+     * @group oauth2-generate-access-token
+     */
     public function testGeneratesRefreshTokenRequests()
     {
         $testConfig = $this->tokenRequestMinimal;
@@ -614,6 +767,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('a_refresh_token', $fields['refresh_token']);
     }
 
+    /**
+     * @group oauth2-generate-access-token
+     */
     public function testClientSecretAddedIfSetForAuthorizationCodeRequests()
     {
         $testConfig = $this->tokenRequestMinimal;
@@ -626,6 +782,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('a_client_secret', $fields['client_secret']);
     }
 
+    /**
+     * @group oauth2-generate-access-token
+     */
     public function testClientSecretAddedIfSetForRefreshTokenRequests()
     {
         $testConfig = $this->tokenRequestMinimal;
@@ -637,6 +796,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('a_client_secret', $fields['client_secret']);
     }
 
+    /**
+     * @group oauth2-generate-access-token
+     */
     public function testClientSecretAddedIfSetForPasswordRequests()
     {
         $testConfig = $this->tokenRequestMinimal;
@@ -649,6 +811,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('a_client_secret', $fields['client_secret']);
     }
 
+    /**
+     * @group oauth2-generate-access-token
+     */
     public function testGeneratesAssertionRequests()
     {
         $testConfig = $this->tokenRequestMinimal;
@@ -665,6 +830,9 @@ class OAuth2Test extends TestCase
         $this->assertArrayHasKey('assertion', $fields);
     }
 
+    /**
+     * @group oauth2-generate-access-token
+     */
     public function testGeneratesExtendedRequests()
     {
         $testConfig = $this->tokenRequestMinimal;
@@ -681,6 +849,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('urn:my_test_grant_type', $fields['grant_type']);
     }
 
+    /**
+     * @group oauth2-generate-access-token
+     */
     public function testTokenUriWithCodeVerifier()
     {
         $codeVerifier = 'my_code_verifier';
@@ -706,6 +877,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals($codeVerifier, $q['code_verifier']);
     }
 
+    /**
+     * @group oauth2-fetch-auth-token
+     */
     public function testFailsOn400()
     {
         $this->expectException(\GuzzleHttp\Exception\ClientException::class);
@@ -718,6 +892,9 @@ class OAuth2Test extends TestCase
         $o->fetchAuthToken($httpHandler);
     }
 
+    /**
+     * @group oauth2-fetch-auth-token
+     */
     public function testFailsOn500()
     {
         $this->expectException(\GuzzleHttp\Exception\ServerException::class);
@@ -730,6 +907,9 @@ class OAuth2Test extends TestCase
         $o->fetchAuthToken($httpHandler);
     }
 
+    /**
+     * @group oauth2-fetch-auth-token
+     */
     public function testFailsOnNoContentTypeIfResponseIsNotJSON()
     {
         $this->expectException(\Exception::class);
@@ -744,6 +924,9 @@ class OAuth2Test extends TestCase
         $o->fetchAuthToken($httpHandler);
     }
 
+    /**
+     * @group oauth2-fetch-auth-token
+     */
     public function testFetchesJsonResponseOnNoContentTypeOK()
     {
         $testConfig = $this->fetchAuthTokenMinimal;
@@ -756,6 +939,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals($tokens['foo'], 'bar');
     }
 
+    /**
+     * @group oauth2-fetch-auth-token
+     */
     public function testFetchesFromFormEncodedResponseOK()
     {
         $testConfig = $this->fetchAuthTokenMinimal;
@@ -773,6 +959,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals($tokens['spice'], 'nice');
     }
 
+    /**
+     * @group oauth2-fetch-auth-token
+     */
     public function testUpdatesTokenFieldsOnFetch()
     {
         $testConfig = $this->fetchAuthTokenMinimal;
@@ -806,6 +995,9 @@ class OAuth2Test extends TestCase
         $this->assertEquals('scope1 scope2', $o->getGrantedScope());
     }
 
+    /**
+     * @group oauth2-fetch-auth-token
+     */
     public function testUpdatesTokenFieldsOnFetchMissingRefreshToken()
     {
         $testConfig = $this->fetchAuthTokenMinimal;
@@ -839,6 +1031,7 @@ class OAuth2Test extends TestCase
 
     /**
      * @dataProvider provideGetLastReceivedToken
+     * @group oauth2-fetch-auth-token
      */
     public function testGetLastReceivedToken(
         $updateToken,
@@ -909,14 +1102,9 @@ class OAuth2Test extends TestCase
         ];
     }
 
-    // public function setUp(): void
-    // {
-    //     $this->publicKey =
-    //         file_get_contents(__DIR__ . '/fixtures' . '/public.pem');
-    //     $this->privateKey =
-    //         file_get_contents(__DIR__ . '/fixtures' . '/private.pem');
-    // }
-
+    /**
+     * @group oauth2-verify-id-token
+     */
     public function testFailsIfIdTokenIsInvalid()
     {
         $this->expectException(UnexpectedValueException::class);
@@ -929,6 +1117,9 @@ class OAuth2Test extends TestCase
         $o->verifyIdToken($publicKey, ['RS256']);
     }
 
+    /**
+     * @group oauth2-verify-id-token
+     */
     public function testFailsIfAudienceIsMissing()
     {
         $this->expectException(DomainException::class);
@@ -948,6 +1139,9 @@ class OAuth2Test extends TestCase
         $o->verifyIdToken($publicKey, ['RS256']);
     }
 
+    /**
+     * @group oauth2-verify-id-token
+     */
     public function testFailsIfAudienceIsWrong()
     {
         $this->expectException(DomainException::class);
@@ -968,6 +1162,9 @@ class OAuth2Test extends TestCase
         $o->verifyIdToken($publicKey, ['RS256']);
     }
 
+    /**
+     * @group oauth2-verify-id-token
+     */
     public function testFailsWithStringPublicKeyAndAllowedAlgsGreaterThanOne()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -981,6 +1178,9 @@ class OAuth2Test extends TestCase
         $o->verifyIdToken($publicKey, ['RS256', 'ES256']);
     }
 
+    /**
+     * @group oauth2-verify-id-token
+     */
     public function testFailsWithStringPublicKeyAndNoAllowedAlgs()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -994,6 +1194,9 @@ class OAuth2Test extends TestCase
         $o->verifyIdToken($publicKey, []);
     }
 
+    /**
+     * @group oauth2-verify-id-token
+     */
     public function testFailsWithStringInPublicKeyArrayAndNoAllowedAlgs()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -1010,6 +1213,9 @@ class OAuth2Test extends TestCase
         ], []);
     }
 
+    /**
+     * @group oauth2-verify-id-token
+     */
     public function testFailsWithInvalidTypeForAllowedAlgs()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -1023,6 +1229,9 @@ class OAuth2Test extends TestCase
         $o->verifyIdToken($publicKey, 123);
     }
 
+    /**
+     * @group oauth2-verify-id-token
+     */
     public function testShouldReturnAValidIdToken()
     {
         $publicKey = file_get_contents(__DIR__ . '/fixtures' . '/public.pem');


### PR DESCRIPTION
Standard PHPUnit is to have only one test class in each test file. Substitute multiple test classes with proper use of the phpunit `@group` tag