### PR TITLE
Load PHPsec public key in PKCS8 format instead of PKCS1

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -408,7 +408,7 @@ class AccessToken
                 $exponent
             ]), 256),
         ]);
-        return $key->toString('PKCS1');
+        return $key->toString('PKCS8');
     }
 
     /**


### PR DESCRIPTION
This is (hopefully) a fix for #457.

It happens specifically with phpseclib 3.x.

---

When using the `AccessToken` class to decode an ID token, the "Federated Sign On" certificates are stored in the PKCS8 format after which the ID token is decoded with `Firebase/JWT`:

```php
$payload = $this->callJwtStatic('decode', [
    $token,
    $keys,
]);
```
Source: [AccessToken.php#L246](https://github.com/googleapis/google-auth-library-php/blob/main/src/AccessToken.php#L246)


Part of decoding the JWT is verifying the token which happens with `openssl_verify`:

```php
$success = \openssl_verify($msg, $signature, $keyMaterial, $algorithm);
```

Source: [JWT.php#L306](https://github.com/firebase/php-jwt/blob/main/src/JWT.php#L306)

I have to be honest that I am completely lacking any knowledge about RSA keys and their encoding, but according to [this StackOverflow issue](https://stackoverflow.com/a/64899836) PHP OpenSSL only accepts ["public key in X.509 style"](https://www.php.net/manual/en/function.openssl-pkey-get-public.php#101513). I can confirm this as I am getting the error "Supplied key param cannot be coerced into a public key" (same as in the linked issue at the start of this comment). After returning the key in PKCS8 format, the issue was fixed.

I understand my assessment of the issue might be completely wrong but I really like to help resolve this issue! 👍 