### PR TITLE
chore: Add version in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "keywords": ["google", "oauth2", "authentication"],
   "homepage": "http://github.com/google/google-auth-library-php",
   "license": "Apache-2.0",
+  "version": "1.33.0",
   "support": {
     "docs": "https://googleapis.github.io/google-auth-library-php/main/"
   },


### PR DESCRIPTION
`release-please` bot updates `CHANGELOG.md` and `composer.json` with every release ([code pointer](https://github.com/googleapis/release-please/blob/main/src/updaters/php/root-composer-update-packages.ts)). Right now auth library's `composer.json` doesn't has any `version` key-value pair. 

Manually adding a `version` in composer ensures release-please updates it with every release.