### PR TITLE
feat: respect sub for domain-wide delegation in service account creds

### DIFF
--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -352,6 +352,12 @@ class ServiceAccountCredentials extends CredentialsLoader implements
      */
     private function useSelfSignedJwt()
     {
+        // When a sub is supplied, the user is using domain-wide delegation, which not available
+        // with self-signed JWTs
+        if (null !== $this->auth->getSub()) {
+            return false;
+        }
+
         // If claims are set, this call is for "id_tokens"
         if ($this->auth->getAdditionalClaims()) {
             return false;

--- a/tests/FetchAuthTokenTest.php
+++ b/tests/FetchAuthTokenTest.php
@@ -168,6 +168,8 @@ class FetchAuthTokenTest extends BaseTest
             ->willReturn($this->scopes);
         $oauth2Mock->getAdditionalClaims()
             ->willReturn([]);
+        $oauth2Mock->getSub()
+            ->willReturn(null);
 
         $credentials = new ServiceAccountCredentials($this->scopes, $jsonPath);
         $property->setValue($credentials, $oauth2Mock->reveal());


### PR DESCRIPTION
This is also a "fix" because, this should always have been the case. We want to respect the "sub" field, and use the oauth token endpoint instead of SSJs when it's supplied.