### PR TITLE
chore: fix php warning in AuthTokenMiddleware

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" convertWarningsToExceptions="false" convertNoticesToExceptions="false" convertErrorsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" convertWarningsToExceptions="true" convertNoticesToExceptions="false" convertErrorsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage>
     <include>
       <directory suffix=".php">src</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" convertWarningsToExceptions="true" convertNoticesToExceptions="false" convertErrorsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" convertWarningsToExceptions="true" convertNoticesToExceptions="false" convertErrorsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage>
     <include>
       <directory suffix=".php">src</directory>

--- a/src/Middleware/AuthTokenMiddleware.php
+++ b/src/Middleware/AuthTokenMiddleware.php
@@ -132,7 +132,7 @@ class AuthTokenMiddleware
         ) {
             $token = $this->fetcher->fetchAuthToken();
             $request = $request->withHeader(
-                'authorization', 'Bearer ' . ($token['access_token'] ?? $token['id_token'])
+                'authorization', 'Bearer ' . ($token['access_token'] ?? $token['id_token'] ?? '')
             );
         } else {
             $headers = $this->fetcher->updateMetadata($request->getHeaders(), null, $this->httpHandler);


### PR DESCRIPTION
A PHP warning was introduced in https://github.com/googleapis/google-auth-library-php/pull/492 where we didn't check if one of the values of the array was set. 

```
$ vendor/bin/phpunit tests/Middleware/AuthTokenMiddlewareTest.php --filter testDoesNotAddAnAuthorizationHeaderOnNoAccessToken
PHPUnit 9.6.13 by Sebastian Bergmann and contributors.

PHP Warning:  Undefined array key "id_token" in src/Middleware/AuthTokenMiddleware.php on line 135
.                                                                   1 / 1 (100%)
Warning: Undefined array key "id_token" in src/Middleware/AuthTokenMiddleware.php on line 135


Time: 00:00.012, Memory: 8.00 MB

OK (1 test, 1 assertion)
```

This is not too concerning, since PHP will cast this to an empty string, but we should get rid of the warning by explicitly using an empty string when neither token types are set. 

Also, we set `convertWarningsToExceptions="true"` and `convertWarningsToExceptions="true"`, where they were previously false. This will ensure warnings like this fail our tests, so they don't happen again.