### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,44 +35,28 @@ composer.phar require google/auth
 ## Application Default Credentials
 
 This library provides an implementation of
-[application default credentials][application default credentials] for PHP.
+[Application Default Credentials (ADC)][application default credentials] for PHP.
 
-The Application Default Credentials provide a simple way to get authorization
-credentials for use in calling Google APIs.
+Application Default Credentials provides a simple way to get authorization
+credentials for use in calling Google APIs, and is
+the recommended approach to authorize calls to Cloud APIs.
 
-They are best suited for cases when the call needs to have the same identity
-and authorization level for the application independent of the user. This is
-the recommended approach to authorize calls to Cloud APIs, particularly when
-you're building an application that uses Google Compute Engine.
+### Set up ADC
 
-#### Download your Service Account Credentials JSON file
+To use ADC, you must set it up by providing credentials.
+How you set up ADC depends on the environment where your code is running,
+and whether you are running code in a test or production environment.
 
-To use `Application Default Credentials`, You first need to download a set of
-JSON credentials for your project. Go to **APIs & Services** > **Credentials** in
-the [Google Developers Console][developer console] and select
-**Service account** from the **Add credentials** dropdown.
+For more information, see [Set up Application Default Credentials][set-up-adc].
 
-> This file is your *only copy* of these credentials. It should never be
-> committed with your source code, and should be stored securely.
-
-Once downloaded, store the path to this file in the
-`GOOGLE_APPLICATION_CREDENTIALS` environment variable.
-
-```php
-putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
-```
-
-> PHP's `putenv` function is just one way to set an environment variable.
-> Consider using `.htaccess` or apache configuration files as well.
-
-#### Enable the API you want to use
+### Enable the API you want to use
 
 Before making your API call, you must be sure the API you're calling has been
 enabled. Go to **APIs & Auth** > **APIs** in the
 [Google Developers Console][developer console] and enable the APIs you'd like to
 call. For the example below, you must enable the `Drive API`.
 
-#### Call the APIs
+### Call the APIs
 
 As long as you update the environment variable below to point to *your* JSON
 credentials file, the following code should output a list of your Drive files.
@@ -316,9 +300,10 @@ hesitate to
 about the client or APIs on [StackOverflow](http://stackoverflow.com).
 
 [google-apis-php-client]: https://github.com/google/google-api-php-client
-[application default credentials]: https://developers.google.com/accounts/docs/application-default-credentials
+[application default credentials]: https://cloud.google.com/docs/authentication/application-default-credentials
 [contributing]: https://github.com/google/google-auth-library-php/tree/main/.github/CONTRIBUTING.md
 [copying]: https://github.com/google/google-auth-library-php/tree/main/COPYING
 [Guzzle]: https://github.com/guzzle/guzzle
 [Guzzle 5]: http://docs.guzzlephp.org/en/5.3
 [developer console]: https://console.developers.google.com
+[set-up-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc


### PR DESCRIPTION
Removing instructions to create a service account key as per go/mitigating-cloud-auth-risk, replacing with full instructions for setting up ADC. Updating to point to Cloud authentication documentation as the source of truth for Cloud developers.

b/270225049