### PR TITLE
Suggestions: Metrics with trait suggestions

### DIFF
--- a/src/Credentials/ExternalAccountCredentials.php
+++ b/src/Credentials/ExternalAccountCredentials.php
@@ -35,7 +35,6 @@ use InvalidArgumentException;
 class ExternalAccountCredentials implements FetchAuthTokenInterface, UpdateMetadataInterface, GetQuotaProjectInterface
 {
     use UpdateMetadataTrait;
-    use MetricsTrait;
 
     private const EXTERNAL_ACCOUNT_TYPE = 'external_account';
 

--- a/src/Credentials/ExternalAccountCredentials.php
+++ b/src/Credentials/ExternalAccountCredentials.php
@@ -25,7 +25,6 @@ use Google\Auth\FetchAuthTokenInterface;
 use Google\Auth\GetQuotaProjectInterface;
 use Google\Auth\HttpHandler\HttpClientCache;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
-use Google\Auth\MetricsTrait;
 use Google\Auth\OAuth2;
 use Google\Auth\UpdateMetadataInterface;
 use Google\Auth\UpdateMetadataTrait;

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -431,8 +431,10 @@ class GCECredentials extends CredentialsLoader implements
             return [];  // return an empty array with no access token
         }
 
-        $metricHeader = $this->getMetricHeader(self::CRED_TYPE, $this->targetAudience ? 'it' : 'at');
-        $response = $this->getFromMetadata($httpHandler, $this->tokenUri, [self::METRIC_METADATA_KEY => $metricHeader]);
+        $authRequestType = $this->targetAudience ? 'it' : 'at';
+        $response = $this->getFromMetadata($httpHandler, $this->tokenUri, [
+            self::METRIC_METADATA_KEY => $this->getMetricHeader(self::CRED_TYPE, $authRequestType)
+        ]);
 
         if ($this->targetAudience) {
             return ['id_token' => $response];

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -352,7 +352,6 @@ class GCECredentials extends CredentialsLoader implements
             ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());
 
         $checkUri = 'http://' . self::METADATA_IP;
-        $metricHeader = [self::METRIC_METADATA_KEY => self::getMetricHeader('', 'mds')];
         for ($i = 1; $i <= self::MAX_COMPUTE_PING_TRIES; $i++) {
             try {
                 // Comment from: oauth2client/client.py
@@ -367,7 +366,10 @@ class GCECredentials extends CredentialsLoader implements
                     new Request(
                         'GET',
                         $checkUri,
-                        [self::FLAVOR_HEADER => 'Google'] + $metricHeader
+                        [
+                            self::FLAVOR_HEADER => 'Google',
+                            self::METRIC_METADATA_KEY => self::getMetricHeader('', 'mds'),
+                        ]
                     ),
                     ['timeout' => self::COMPUTE_PING_CONNECTION_TIMEOUT_S]
                 );

--- a/src/Credentials/ImpersonatedServiceAccountCredentials.php
+++ b/src/Credentials/ImpersonatedServiceAccountCredentials.php
@@ -128,10 +128,9 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
      */
     public function fetchAuthToken(callable $httpHandler = null)
     {
-        // We don't support id token endpoint requests as of now for Impersonated Cred
-        $isAccessTokenRequest = true;
-        $metricHeader = $this->getMetricHeader(self::CRED_TYPE, 'at');
-        return $this->sourceCredentials->fetchAuthToken($httpHandler, $metricHeader);
+        return $this->sourceCredentials->fetchAuthToken($httpHandler, [
+            self::METRIC_METADATA_KEY => $this->getMetricHeader(self::CRED_TYPE, 'at')
+        ]);
     }
 
     /**

--- a/src/Credentials/ImpersonatedServiceAccountCredentials.php
+++ b/src/Credentials/ImpersonatedServiceAccountCredentials.php
@@ -27,6 +27,13 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
     use IamSignerTrait;
 
     /**
+     * Used in observability metric headers
+     *
+     * @var string
+     */
+    private const CRED_TYPE = 'imp';
+
+    /**
      * @var string
      */
     protected $impersonatedServiceAccountName;
@@ -35,13 +42,6 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
      * @var UserRefreshCredentials
      */
     protected $sourceCredentials;
-
-    /**
-     * Used in observability metric headers
-     *
-     * @var string
-     */
-    protected $credType = 'cred-type/imp';
 
     /**
      * Instantiate an instance of ImpersonatedServiceAccountCredentials from a credentials file that
@@ -130,11 +130,8 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
     {
         // We don't support id token endpoint requests as of now for Impersonated Cred
         $isAccessTokenRequest = true;
-        $metricsHeader = $this->applyMetricsHeader(
-            [],
-            $this->getTokenEndpointMetricsHeaderValue($isAccessTokenRequest)
-        );
-        return $this->sourceCredentials->fetchAuthToken($httpHandler, $metricsHeader);
+        $metricHeader = $this->getMetricHeader(self::CRED_TYPE, 'at');
+        return $this->sourceCredentials->fetchAuthToken($httpHandler, $metricHeader);
     }
 
     /**
@@ -151,5 +148,10 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
     public function getLastReceivedToken()
     {
         return $this->sourceCredentials->getLastReceivedToken();
+    }
+
+    public function getCredType(): string
+    {
+        return self::CRED_TYPE;
     }
 }

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -213,9 +213,10 @@ class ServiceAccountCredentials extends CredentialsLoader implements
 
             return $accessToken;
         }
-        $isAccessTokenRequest = empty($this->auth->getAdditionalClaims()['target_audience']);
-        $metricHeader = $this->getMetricHeader(self::CRED_TYPE, $isAccessTokenRequest ? 'at' : 'it');
-        return $this->auth->fetchAuthToken($httpHandler, [self::METRIC_METADATA_KEY => $metricHeader]);
+        $authRequestType = empty($this->auth->getAdditionalClaims()['target_audience']) ? 'at' : 'it';
+        return $this->auth->fetchAuthToken($httpHandler, [
+            self::METRIC_METADATA_KEY => $this->getMetricHeader(self::CRED_TYPE, $authRequestType),
+        ]);
     }
 
     /**

--- a/src/Credentials/ServiceAccountJwtAccessCredentials.php
+++ b/src/Credentials/ServiceAccountJwtAccessCredentials.php
@@ -41,6 +41,13 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
     use ServiceAccountSignerTrait;
 
     /**
+     * Used in observability metric headers
+     *
+     * @var string
+     */
+    private const CRED_TYPE = 'jwt';
+
+    /**
      * The OAuth2 instance used to conduct authorization.
      *
      * @var OAuth2
@@ -53,13 +60,6 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
      * @var string
      */
     protected $quotaProject;
-
-    /**
-     * Used in observability metric headers
-     *
-     * @var string
-     */
-    protected $credType = 'cred-type/jwt';
 
     /**
      * @var string
@@ -211,5 +211,10 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
     public function getQuotaProject()
     {
         return $this->quotaProject;
+    }
+
+    public function getCredType(): string
+    {
+        return self::CRED_TYPE;
     }
 }

--- a/src/Credentials/UserRefreshCredentials.php
+++ b/src/Credentials/UserRefreshCredentials.php
@@ -105,7 +105,7 @@ class UserRefreshCredentials extends CredentialsLoader implements GetQuotaProjec
 
     /**
      * @param callable $httpHandler
-     * @param array<mixed> $header [optional] Headers to be passed to the token endpoint request.
+     * @param array<mixed> $headers [optional] Headers to be passed to the token endpoint request.
      *     This is used by ImersonatedServiceAccountCredentials as it uses UserRefreshCredentials
      *     as source credentials.
      *
@@ -119,7 +119,7 @@ class UserRefreshCredentials extends CredentialsLoader implements GetQuotaProjec
      *     @type string $id_token
      * }
      */
-    public function fetchAuthToken(callable $httpHandler = null, array $header = [])
+    public function fetchAuthToken(callable $httpHandler = null, array $headers = [])
     {
         // ImersonatedServiceAccountCredentials will propagate it's own header value, hence
         // we'll pass them if present, else create headers for UserCred and pass along.

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -34,7 +34,6 @@ abstract class CredentialsLoader implements
     FetchAuthTokenInterface,
     UpdateMetadataInterface
 {
-    use MetricsTrait;
     use UpdateMetadataTrait;
 
     const TOKEN_CREDENTIAL_URI = 'https://oauth2.googleapis.com/token';

--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -32,6 +32,7 @@ class FetchAuthTokenCache implements
     UpdateMetadataInterface
 {
     use CacheTrait;
+    use MetricsTrait;
 
     /**
      * @var FetchAuthTokenInterface
@@ -237,6 +238,10 @@ class FetchAuthTokenCache implements
                 $metadata[self::AUTH_METADATA_KEY] = [
                     'Bearer ' . $cached['access_token']
                 ];
+                // Also set the metrics header.
+                if (!isset($metadata[self::METRIC_METADATA_KEY]) && $credType = $this->fetcher->getCredType()) {
+                    $metadata[self::METRIC_METADATA_KEY] = $this->getMetricHeader($credType);
+                }
             }
         }
 

--- a/src/MetricsTrait.php
+++ b/src/MetricsTrait.php
@@ -48,7 +48,7 @@ trait MetricsTrait
     private static function getVersion(): string
     {
         if (is_null(self::$version)) {
-            $versionFilePath = implode(DIRECTORY_SEPARATOR, [__DIR__, '..', 'VERSION']);
+            $versionFilePath = __DIR__ . '/../VERSION';
             self::$version = trim((string) file_get_contents($versionFilePath));
         }
         return self::$version;

--- a/src/MetricsTrait.php
+++ b/src/MetricsTrait.php
@@ -55,8 +55,8 @@ trait MetricsTrait
     }
 
     /**
-     * @var string The credential type for the observability metrics.
-     *             This will be overridden by the credential class if applicable.
+     * The credential type for the observability metrics.
+     * This will be overridden by the credential class if applicable.
      */
     public function getCredType(): string
     {

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -572,11 +572,11 @@ class OAuth2 implements FetchAuthTokenInterface
      * Generates a request for token credentials.
      *
      * @param callable $httpHandler callback which delivers psr7 request
-     * @param array<mixed> $metricsHeader [optional] Metrics headers to be inserted
+     * @param array<mixed> $headers [optional] Headers to be inserted
      *     into the token endpoint request present.
      * @return RequestInterface the authorization Url.
      */
-    public function generateCredentialsRequest(callable $httpHandler = null, $metricsHeader = [])
+    public function generateCredentialsRequest(callable $httpHandler = null, $headers = [])
     {
         $uri = $this->getTokenCredentialUri();
         if (is_null($uri)) {
@@ -635,7 +635,7 @@ class OAuth2 implements FetchAuthTokenInterface
         $headers = [
             'Cache-Control' => 'no-store',
             'Content-Type' => 'application/x-www-form-urlencoded',
-        ] + $metricsHeader;
+        ] + $headers;
 
         return new Request(
             'POST',
@@ -649,17 +649,16 @@ class OAuth2 implements FetchAuthTokenInterface
      * Fetches the auth tokens based on the current state.
      *
      * @param callable $httpHandler callback which delivers psr7 request
-     * @param array<mixed> $metricsHeader [optional] If present, add these headers to the token
-     *        endpoint request.
+     * @param array<mixed> $headers [optional] If present, add these headers to the token request.
      * @return array<mixed> the response
      */
-    public function fetchAuthToken(callable $httpHandler = null, $metricsHeader = [])
+    public function fetchAuthToken(callable $httpHandler = null, $headers = [])
     {
         if (is_null($httpHandler)) {
             $httpHandler = HttpHandlerFactory::build(HttpClientCache::getHttpClient());
         }
 
-        $response = $httpHandler($this->generateCredentialsRequest($httpHandler, $metricsHeader));
+        $response = $httpHandler($this->generateCredentialsRequest($httpHandler, $headers));
         $credentials = $this->parseTokenResponse($response);
         $this->updateToken($credentials);
         if (isset($credentials['scope'])) {

--- a/src/UpdateMetadataInterface.php
+++ b/src/UpdateMetadataInterface.php
@@ -24,6 +24,7 @@ namespace Google\Auth;
 interface UpdateMetadataInterface
 {
     const AUTH_METADATA_KEY = 'authorization';
+    const METRIC_METADATA_KEY = 'x-goog-api-client';
 
     /**
      * Updates metadata with the authorization token.
@@ -38,4 +39,6 @@ interface UpdateMetadataInterface
         $authUri = null,
         callable $httpHandler = null
     );
+
+    public function getCredType(): string;
 }

--- a/src/UpdateMetadataTrait.php
+++ b/src/UpdateMetadataTrait.php
@@ -26,6 +26,8 @@ namespace Google\Auth;
  */
 trait UpdateMetadataTrait
 {
+    use MetricsTrait;
+
     /**
      * export a callback function which updates runtime metadata.
      *
@@ -50,16 +52,15 @@ trait UpdateMetadataTrait
         $authUri = null,
         callable $httpHandler = null
     ) {
-        $metadata_copy = $metadata;
-        $metadata_copy = $this->applyMetricsHeader(
-            $metadata_copy,
-            $this->getServiceApiMetricsHeaderValue()
-        );
-
-        if (isset($metadata_copy[self::AUTH_METADATA_KEY])) {
+        if (isset($metadata[self::AUTH_METADATA_KEY])) {
             // Auth metadata has already been set
-            return $metadata_copy;
+            return $metadata;
         }
+        $metadata_copy = $metadata;
+        if (!isset($metadata_copy[self::METRIC_METADATA_KEY]) && $credType = $this->getCredType()) {
+            $metadata_copy[self::METRIC_METADATA_KEY] = $this->getMetricHeader($credType);
+        }
+
         $result = $this->fetchAuthToken($httpHandler);
         if (isset($result['access_token'])) {
             $metadata_copy[self::AUTH_METADATA_KEY] = ['Bearer ' . $result['access_token']];

--- a/tests/FetchAuthTokenCacheTest.php
+++ b/tests/FetchAuthTokenCacheTest.php
@@ -124,6 +124,9 @@ class FetchAuthTokenCacheTest extends BaseTest
         $this->mockFetcher->getCacheKey()
             ->shouldBeCalled()
             ->willReturn($cacheKey);
+        $this->mockFetcher->getCredType()
+            ->shouldBeCalled()
+            ->willReturn('');
         $this->mockFetcher->updateMetadata(Argument::type('array'), null, null)
             ->shouldBeCalled()
             ->will(function ($args, $fetcher) {

--- a/tests/MetricsTraitTest.php
+++ b/tests/MetricsTraitTest.php
@@ -47,11 +47,6 @@ class MetricsTraitTest extends TestCase
             use MetricsTrait {
                 getVersion as public;
             }
-            public function applyMetricsHeader($metadata, $headerValue)
-            {
-                $metadata[UpdateMetadataInterface::METRIC_METADATA_KEY] = [$headerValue];
-                return $metadata;
-            }
         };
         $this->langAndVersion = sprintf(
             'gl-php/%s auth/%s',
@@ -159,16 +154,6 @@ class MetricsTraitTest extends TestCase
     }
 
     /**
-     * @dataProvider headerCases
-     */
-    public function testApplyMetricsHeader($existingValue, $expected)
-    {
-        $metadata = [self::$headerKey => $existingValue];
-        $metadata = $this->impl->applyMetricsHeader($metadata, 'bar');
-        $this->assertEquals($expected, $metadata[self::$headerKey]);
-    }
-
-    /**
      * Invokes the 'updateMetadata' method of cred fetcher with empty metadata argument
      * and asserts for proper service api usage observability metrics header.
      */
@@ -214,16 +199,6 @@ class MetricsTraitTest extends TestCase
                 return new Response(200, [], Utils::streamFor($jsonTokens));
             }
         ]);
-    }
-
-    public function headerCases()
-    {
-        return [
-            ['', ['bar']],
-            ['foo', ['bar']],
-            [[], ['bar']],
-            [['foo'], ['bar']],
-        ];
     }
 
     public function tokenRequestType()

--- a/tests/MetricsTraitTest.php
+++ b/tests/MetricsTraitTest.php
@@ -47,7 +47,8 @@ class MetricsTraitTest extends TestCase
             use MetricsTrait {
                 getVersion as public;
             }
-            public function applyMetricsHeader($metadata, $headerValue) {
+            public function applyMetricsHeader($metadata, $headerValue)
+            {
                 $metadata[UpdateMetadataInterface::METRIC_METADATA_KEY] = [$headerValue];
                 return $metadata;
             }


### PR DESCRIPTION
Suggestions for https://github.com/googleapis/google-auth-library-php/pull/509

Major changes:
 - Consolidate all header methods to one `getMetricHeader` for simplicity, and remove `applyHeaders`
 - If a metrics header is supplied in the metadata, it will be used instead of the default (rather than having multiple metrics headers)
 - Add headers in `FetchAuthTokenCache` when a cached token is found (rather than in `CredentialsLoader`)

Minor changes
 - Make `$credType` a constant and add `getCredType` method to each Credential (and to `UpdateMetadataInterface`)
 - Make `$metricsHeaderKey` a constant and move it to `UpdateMetadataInterface::METRIC_METADATA_KEY` (to be consistent with `AUTH_METADATA_KEY`)
 - Rename all `$metricsHeaders` parameters to `$headers`, as this is more accurate.
 - Import `MetricsTrait` in `UpdateMetadataTrait` (since it depends on this)
 - Make `getVersion` private