### PR TITLE
feat: ServiceAccountJwtAccessCredentials omits expires_in and token_type

### DIFF
--- a/src/Credentials/ServiceAccountJwtAccessCredentials.php
+++ b/src/Credentials/ServiceAccountJwtAccessCredentials.php
@@ -151,7 +151,11 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
         // Set the self-signed access token in OAuth2 for getLastReceivedToken
         $this->auth->setAccessToken($access_token);
 
-        return ['access_token' => $access_token];
+        return [
+            'access_token' => $access_token,
+            'expires_in' => $this->auth->getExpiry(),
+            'token_type' => 'Bearer'
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixing two issues here:

1) Returning `type` and `expires_in` with the token in case of JWT keys. ref: https://github.com/googleapis/google-cloud-php/pull/6850#issuecomment-1872164327 ![Screenshot 2023-12-28 at 00 06 36](https://github.com/googleapis/google-auth-library-php/assets/7369612/f1934e41-4cce-43ee-bab0-6eaa27c64f5f)

2) Fixing lint issues with `AccessToken.php`:
The lint check is complaining about retuning `string|array` in `loadPhpsecPublicKey` method ([ref](https://github.com/googleapis/google-auth-library-php/actions/runs/7357834969/job/20030094538?pr=513)) and expects a `string` instead. I am not sure whether this is the best fix, but looks like `__toString` method ([ref](https://github.com/phpseclib/phpseclib/blob/498e67a0c82bd5791fda9b0dd0f4ec8e8aebb02d/phpseclib/Crypt/RSA.php#L2070)) is marked as `public` also returns a key. Throwing a `TypeError` if the key is array and not a string since thats consistent with an existing error in that case from [here](https://github.com/firebase/php-jwt/blob/1b9e87184745595ef70540613c0cb9de09bebab3/src/Key.php#L31).


We confirmed that the `access_token` cannot have any other `type` and `expires_in` is usually ~3600 always. So, this change might be redundant, but IMHO its good to have.
