### PR TITLE
chore: fix style check

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -399,7 +399,10 @@ class AccessToken
         }
     }
 
-    private function loadPhpsecPublicKey(string $modulus, string $exponent): string
+    /**
+     * @return string|array
+     */
+    private function loadPhpsecPublicKey(string $modulus, string $exponent)
     {
         if (class_exists(RSA::class) && class_exists(BigInteger2::class)) {
             $key = new RSA();
@@ -411,7 +414,7 @@ class AccessToken
                     $exponent
                 ]), 256),
             ]);
-            return $key->__toString();
+            return $key->getPublicKey();
         }
         $key = PublicKeyLoader::load([
             'n' => new BigInteger3($this->callJwtStatic('urlsafeB64Decode', [

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -38,6 +38,7 @@ use SimpleJWT\InvalidTokenException;
 use SimpleJWT\JWT as SimpleJWT;
 use SimpleJWT\Keys\KeyFactory;
 use SimpleJWT\Keys\KeySet;
+use TypeError;
 use UnexpectedValueException;
 
 /**
@@ -400,7 +401,8 @@ class AccessToken
     }
 
     /**
-     * @return string|array
+     * @return string
+     * @throws TypeError If the key cannot be initialized to a string.
      */
     private function loadPhpsecPublicKey(string $modulus, string $exponent)
     {
@@ -414,7 +416,11 @@ class AccessToken
                     $exponent
                 ]), 256),
             ]);
-            return $key->getPublicKey();
+            $formattedPublicKey = $key->getPublicKey();
+            if (is_string($formattedPublicKey)) {
+                return $formattedPublicKey;
+            }
+            throw new TypeError('Failed to initialize the key');
         }
         $key = PublicKeyLoader::load([
             'n' => new BigInteger3($this->callJwtStatic('urlsafeB64Decode', [
@@ -424,7 +430,12 @@ class AccessToken
                 $exponent
             ]), 256),
         ]);
-        return $key->toString('PKCS8');
+        // Ensure the key is correctly initialized
+        $formattedPublicKey = $key->toString('PKCS8');
+        if (is_string($formattedPublicKey)) {
+            return $formattedPublicKey;
+        }
+        throw new TypeError('Failed to initialize the key');
     }
 
     /**

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -411,7 +411,7 @@ class AccessToken
                     $exponent
                 ]), 256),
             ]);
-            return $key->getPublicKey();
+            return $key->__toString();
         }
         $key = PublicKeyLoader::load([
             'n' => new BigInteger3($this->callJwtStatic('urlsafeB64Decode', [


### PR DESCRIPTION
The lint check is complaining about retuning `string|array` in `loadPhpsecPublicKey` method ([ref](https://github.com/googleapis/google-auth-library-php/actions/runs/7357834969/job/20030094538?pr=513)) and expects a `string` instead.

I am not sure whether this is the best fix, but looks like `__toString` method ([ref](https://github.com/phpseclib/phpseclib/blob/498e67a0c82bd5791fda9b0dd0f4ec8e8aebb02d/phpseclib/Crypt/RSA.php#L2070)) is marked as `public` also returns a key.

Throwing a `TypeError` if the key is array and not a string since thats consistent with an existing error in that case from [here](https://github.com/firebase/php-jwt/blob/1b9e87184745595ef70540613c0cb9de09bebab3/src/Key.php#L31).
