### PR TITLE
fix: lint error from new phpseclib

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -38,6 +38,7 @@ use SimpleJWT\InvalidTokenException;
 use SimpleJWT\JWT as SimpleJWT;
 use SimpleJWT\Keys\KeyFactory;
 use SimpleJWT\Keys\KeySet;
+use TypeError;
 use UnexpectedValueException;
 
 /**
@@ -399,6 +400,10 @@ class AccessToken
         }
     }
 
+    /**
+     * @return string
+     * @throws TypeError If the key cannot be initialized to a string.
+     */
     private function loadPhpsecPublicKey(string $modulus, string $exponent): string
     {
         if (class_exists(RSA::class) && class_exists(BigInteger2::class)) {
@@ -421,7 +426,11 @@ class AccessToken
                 $exponent
             ]), 256),
         ]);
-        return $key->toString('PKCS8');
+        $formattedPublicKey = $key->toString('PKCS8');
+        if (!is_string($formattedPublicKey)) {
+            throw new TypeError('Failed to initialize the key');
+        }
+        return $formattedPublicKey;
     }
 
     /**


### PR DESCRIPTION
Fixes a linting error caused in the latest version ([3.0.35](https://github.com/phpseclib/phpseclib/releases/tag/3.0.35)) of PHPSeclib due to the `AsymmetricKey::toString` function [having its return type changed](https://github.com/phpseclib/phpseclib/blame/4b1827beabce71953ca479485c0ae9c51287f2fe/phpseclib/Crypt/Common/AsymmetricKey.php#L97) from `string` to `string|array`

Splitting this PR: 
https://github.com/googleapis/google-auth-library-php/pull/513, will mark https://github.com/googleapis/google-auth-library-php/pull/515 as covered with this one.