### PR TITLE
deprecate: remove support for phpseclib V2

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -396,24 +396,6 @@ class AccessToken
         if (!class_exists(RSA::class)) {
             throw new RuntimeException('Please require phpseclib/phpseclib v2 or v3 to use this utility.');
         }
-
-        /**
-         * phpseclib calls "phpinfo" by default, which requires special
-         * whitelisting in the AppEngine VM environment. This function
-         * sets constants to bypass the need for phpseclib to check phpinfo
-         *
-         * @see phpseclib/Math/BigInteger
-         * @see https://github.com/GoogleCloudPlatform/getting-started-php/issues/85
-         * @codeCoverageIgnore
-         */
-        if (filter_var(getenv('GAE_VM'), FILTER_VALIDATE_BOOLEAN)) {
-            if (!defined('MATH_BIGINTEGER_OPENSSL_ENABLED')) {
-                define('MATH_BIGINTEGER_OPENSSL_ENABLED', true);
-            }
-            if (!defined('CRYPT_RSA_MODE')) {
-                define('CRYPT_RSA_MODE', RSA::MODE_OPENSSL);
-            }
-        }
     }
 
     private function loadPhpsecPublicKey(string $modulus, string $exponent): string

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -395,7 +395,7 @@ class AccessToken
     private function checkAndInitializePhpsec()
     {
         if (!class_exists(RSA::class)) {
-            throw new RuntimeException('Please require phpseclib/phpseclib v2 or v3 to use this utility.');
+            throw new RuntimeException('Please require phpseclib/phpseclib v3 to use this utility.');
         }
     }
 

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -29,8 +29,8 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 use InvalidArgumentException;
 use phpseclib3\Crypt\PublicKeyLoader;
-use phpseclib3\Math\BigInteger as BigInteger3;
 use phpseclib3\Crypt\RSA;
+use phpseclib3\Math\BigInteger;
 use Psr\Cache\CacheItemPoolInterface;
 use RuntimeException;
 use SimpleJWT\InvalidTokenException;
@@ -419,10 +419,10 @@ class AccessToken
     private function loadPhpsecPublicKey(string $modulus, string $exponent): string
     {
         $key = PublicKeyLoader::load([
-            'n' => new BigInteger3($this->callJwtStatic('urlsafeB64Decode', [
+            'n' => new BigInteger($this->callJwtStatic('urlsafeB64Decode', [
                 $modulus,
             ]), 256),
-            'e' => new BigInteger3($this->callJwtStatic('urlsafeB64Decode', [
+            'e' => new BigInteger($this->callJwtStatic('urlsafeB64Decode', [
                 $exponent
             ]), 256),
         ]);

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -28,8 +28,6 @@ use Google\Auth\HttpHandler\HttpHandlerFactory;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 use InvalidArgumentException;
-use phpseclib\Crypt\RSA;
-use phpseclib\Math\BigInteger as BigInteger2;
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Math\BigInteger as BigInteger3;
 use Psr\Cache\CacheItemPoolInterface;
@@ -394,25 +392,13 @@ class AccessToken
      */
     private function checkAndInitializePhpsec()
     {
-        if (!$this->checkAndInitializePhpsec2() && !$this->checkPhpsec3()) {
+        if (!$this->checkPhpsec3()) {
             throw new RuntimeException('Please require phpseclib/phpseclib v2 or v3 to use this utility.');
         }
     }
 
     private function loadPhpsecPublicKey(string $modulus, string $exponent): string
     {
-        if (class_exists(RSA::class) && class_exists(BigInteger2::class)) {
-            $key = new RSA();
-            $key->loadKey([
-                'n' => new BigInteger2($this->callJwtStatic('urlsafeB64Decode', [
-                    $modulus,
-                ]), 256),
-                'e' => new BigInteger2($this->callJwtStatic('urlsafeB64Decode', [
-                    $exponent
-                ]), 256),
-            ]);
-            return $key->getPublicKey();
-        }
         $key = PublicKeyLoader::load([
             'n' => new BigInteger3($this->callJwtStatic('urlsafeB64Decode', [
                 $modulus,
@@ -427,39 +413,9 @@ class AccessToken
     /**
      * @return bool
      */
-    private function checkAndInitializePhpsec2(): bool
-    {
-        if (!class_exists('phpseclib\Crypt\RSA')) {
-            return false;
-        }
-
-        /**
-         * phpseclib calls "phpinfo" by default, which requires special
-         * whitelisting in the AppEngine VM environment. This function
-         * sets constants to bypass the need for phpseclib to check phpinfo
-         *
-         * @see phpseclib/Math/BigInteger
-         * @see https://github.com/GoogleCloudPlatform/getting-started-php/issues/85
-         * @codeCoverageIgnore
-         */
-        if (filter_var(getenv('GAE_VM'), FILTER_VALIDATE_BOOLEAN)) {
-            if (!defined('MATH_BIGINTEGER_OPENSSL_ENABLED')) {
-                define('MATH_BIGINTEGER_OPENSSL_ENABLED', true);
-            }
-            if (!defined('CRYPT_RSA_MODE')) {
-                define('CRYPT_RSA_MODE', RSA::MODE_OPENSSL);
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * @return bool
-     */
     private function checkPhpsec3(): bool
     {
-        return class_exists('phpseclib3\Crypt\RSA');
+        return class_exists(phpseclib3\Crypt\RSA::class);
     }
 
     /**

--- a/src/ServiceAccountSignerTrait.php
+++ b/src/ServiceAccountSignerTrait.php
@@ -17,7 +17,7 @@
 
 namespace Google\Auth;
 
-use phpseclib\Crypt\RSA;
+use phpseclib3\Crypt\RSA;
 
 /**
  * Sign a string using a Service Account private key.
@@ -37,11 +37,9 @@ trait ServiceAccountSignerTrait
         $privateKey = $this->auth->getSigningKey();
 
         $signedString = '';
-        if (class_exists('\\phpseclib\\Crypt\\RSA') && !$forceOpenssl) {
-            $rsa = new RSA();
-            $rsa->loadKey($privateKey);
-            $rsa->setSignatureMode(RSA::SIGNATURE_PKCS1);
-            $rsa->setHash('sha256');
+        if (class_exists(phpseclib3\Crypt\RSA::class) && !$forceOpenssl) {
+            $key = PublicKeyLoader::load($privateKey);
+            $rsa = $key->withHash('sha256')->withPadding(RSA::SIGNATURE_PKCS1);
 
             $signedString = $rsa->sign($stringToSign);
         } elseif (extension_loaded('openssl')) {

--- a/src/ServiceAccountSignerTrait.php
+++ b/src/ServiceAccountSignerTrait.php
@@ -17,6 +17,7 @@
 
 namespace Google\Auth;
 
+use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Crypt\RSA;
 
 /**


### PR DESCRIPTION
Unit Tests are working in my local. 

I linked the new auth library all the way upto `google-cloud-php` and ran storage system tests against PROD, and they pass. Hence, i am confident the changes are good to review.