### PR TITLE
Disallow vulnerable Guzzle versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": "^7.4||^8.0",
     "firebase/php-jwt": "^6.0",
-    "guzzlehttp/guzzle": "^6.2.1|^7.0",
+    "guzzlehttp/guzzle": "^6.5.8||^7.4.5",
     "guzzlehttp/psr7": "^2.4.5",
     "psr/http-message": "^1.1||^2.0",
     "psr/cache": "^1.0||^2.0||^3.0"


### PR DESCRIPTION
Disallow Guzzle versions listed in vulnerability [CVE-2022-31090](https://github.com/advisories/GHSA-25mq-v84q-4j7r) in same way as in googleapis/google-api-php-client library by [PR2536](https://github.com/googleapis/google-api-php-client/pull/2536).