### PR TITLE
fix: use gmdate to format x-amz-date with UTC irrespective of timezone

### DIFF
--- a/src/CredentialSource/AwsNativeSource.php
+++ b/src/CredentialSource/AwsNativeSource.php
@@ -153,8 +153,8 @@ class AwsNativeSource implements ExternalAccountCredentialSourceInterface
         $service = 'sts';
 
         # Create a date for headers and the credential string in ISO-8601 format
-        $amzdate = date('Ymd\THis\Z');
-        $datestamp = date('Ymd'); # Date w/o time, used in credential scope
+        $amzdate = gmdate('Ymd\THis\Z');
+        $datestamp = gmdate('Ymd'); # Date w/o time, used in credential scope
 
         # Create the canonical headers and signed headers. Header names
         # must be trimmed and lowercase, and sorted in code point order from


### PR DESCRIPTION
## Issue

Currently the value for `x-amz-date` is generated from [date](https://www.php.net/manual/en/function.date.php) function, but if user sets a different timezone other than UTC, the generated timestamp has an invalid timestamp.

This causes the following `SignatureDoesNotMatch` error when authenticating with Workload Identity Federation:

When the timezone is older than UTC:

```
{"error":"invalid_grant","error_description":"The given AWS signed request is expired."}
```

When the timezone is later than UTC:
```
{"error":"invalid_grant","error_description":"Received invalid AWS response of type SignatureDoesNotMatch with error message: Signature not yet current: 20240305T152423Z is still later than 20240305T063924Z (20240305T062424Z + 15 min.)"}
```

This happens because `date('Ymd\THis\Z')` produces timezone-aware timestamp, but the suffix is always `Z` (UTC).

## Reproduce

We can easily reproduce this issue just adding `date_default_timezone_set('America/Los_Angeles');` to the code.

Also the following code illustrates how `date('Ymd\THis\Z')` produces invalid timestamp.

```
$ date
Tue Mar  5 06:37:39 UTC 2024

$ php -a
php > echo date('Ymd\THis\Z');
20240305T063748Z

php > date_default_timezone_set('America/Los_Angeles');

php > echo date('Ymd\THis\Z');
20240304T223756Z
```

## How to fix this

I changed the code to use [gmdate](https://www.php.net/manual/en/function.gmdate.php) instead of [date](https://www.php.net/manual/en/function.date.php) function irrespective of the timezone the user sets.

I locally changed the code and confirmed that this fix works even if a different timezone is set in the code.