### PR TITLE
fix: Compatability with php 8.4

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -65,12 +65,12 @@ class AccessToken
     private $cache;
 
     /**
-     * @param callable $httpHandler [optional] An HTTP Handler to deliver PSR-7 requests.
-     * @param CacheItemPoolInterface $cache [optional] A PSR-6 compatible cache implementation.
+     * @param callable|null $httpHandler [optional] An HTTP Handler to deliver PSR-7 requests.
+     * @param CacheItemPoolInterface|null $cache [optional] A PSR-6 compatible cache implementation.
      */
     public function __construct(
-        callable $httpHandler = null,
-        CacheItemPoolInterface $cache = null
+        ?callable $httpHandler = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $this->httpHandler = $httpHandler
             ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());

--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -80,18 +80,18 @@ class ApplicationDefaultCredentials
      *
      * @param string|string[] $scope the scope of the access request, expressed
      *        either as an Array or as a space-delimited String.
-     * @param callable $httpHandler callback which delivers psr7 request
-     * @param array<mixed> $cacheConfig configuration for the cache when it's present
-     * @param CacheItemPoolInterface $cache A cache implementation, may be
+     * @param callable|null $httpHandler callback which delivers psr7 request
+     * @param array<mixed>|null $cacheConfig configuration for the cache when it's present
+     * @param CacheItemPoolInterface|null $cache A cache implementation, may be
      *        provided if you have one already available for use.
      * @return AuthTokenSubscriber
      * @throws DomainException if no implementation can be obtained.
      */
     public static function getSubscriber(// @phpstan-ignore-line
         $scope = null,
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $creds = self::getCredentials($scope, $httpHandler, $cacheConfig, $cache);
 
@@ -108,9 +108,9 @@ class ApplicationDefaultCredentials
      *
      * @param string|string[] $scope the scope of the access request, expressed
      *        either as an Array or as a space-delimited String.
-     * @param callable $httpHandler callback which delivers psr7 request
-     * @param array<mixed> $cacheConfig configuration for the cache when it's present
-     * @param CacheItemPoolInterface $cache A cache implementation, may be
+     * @param callable|null $httpHandler callback which delivers psr7 request
+     * @param array<mixed>|null $cacheConfig configuration for the cache when it's present
+     * @param CacheItemPoolInterface|null $cache A cache implementation, may be
      *        provided if you have one already available for use.
      * @param string $quotaProject specifies a project to bill for access
      *   charges associated with the request.
@@ -119,9 +119,9 @@ class ApplicationDefaultCredentials
      */
     public static function getMiddleware(
         $scope = null,
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null,
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null,
         $quotaProject = null
     ) {
         $creds = self::getCredentials($scope, $httpHandler, $cacheConfig, $cache, $quotaProject);
@@ -135,16 +135,16 @@ class ApplicationDefaultCredentials
      *
      * @param string|string[] $scope the scope of the access request, expressed
      *        either as an Array or as a space-delimited String.
-     * @param callable $httpHandler callback which delivers psr7 request
-     * @param array<mixed> $cacheConfig configuration for the cache when it's present
-     * @param CacheItemPoolInterface $cache A cache implementation, may be
+     * @param callable|null $httpHandler callback which delivers psr7 request
+     * @param array<mixed>|null $cacheConfig configuration for the cache when it's present
+     * @param CacheItemPoolInterface|null $cache A cache implementation, may be
      *        provided if you have one already available for use.
-     * @param string $quotaProject specifies a project to bill for access
+     * @param string|null $quotaProject specifies a project to bill for access
      *   charges associated with the request.
-     * @param string|string[] $defaultScope The default scope to use if no
+     * @param string|string[]|null $defaultScope The default scope to use if no
      *   user-defined scopes exist, expressed either as an Array or as a
      *   space-delimited string.
-     * @param string $universeDomain Specifies a universe domain to use for the
+     * @param string|null $universeDomain Specifies a universe domain to use for the
      *   calling client library
      *
      * @return FetchAuthTokenInterface
@@ -152,12 +152,12 @@ class ApplicationDefaultCredentials
      */
     public static function getCredentials(
         $scope = null,
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null,
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null,
         $quotaProject = null,
         $defaultScope = null,
-        string $universeDomain = null
+        ?string $universeDomain = null
     ) {
         $creds = null;
         $jsonKey = CredentialsLoader::fromEnv()
@@ -215,18 +215,18 @@ class ApplicationDefaultCredentials
      * ID token.
      *
      * @param string $targetAudience The audience for the ID token.
-     * @param callable $httpHandler callback which delivers psr7 request
-     * @param array<mixed> $cacheConfig configuration for the cache when it's present
-     * @param CacheItemPoolInterface $cache A cache implementation, may be
+     * @param callable|null $httpHandler callback which delivers psr7 request
+     * @param array<mixed>|null $cacheConfig configuration for the cache when it's present
+     * @param CacheItemPoolInterface|null $cache A cache implementation, may be
      *        provided if you have one already available for use.
      * @return AuthTokenMiddleware
      * @throws DomainException if no implementation can be obtained.
      */
     public static function getIdTokenMiddleware(
         $targetAudience,
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $creds = self::getIdTokenCredentials($targetAudience, $httpHandler, $cacheConfig, $cache);
 
@@ -242,18 +242,18 @@ class ApplicationDefaultCredentials
      * ID token.
      *
      * @param string $targetAudience The audience for the ID token.
-     * @param callable $httpHandler callback which delivers psr7 request
-     * @param array<mixed> $cacheConfig configuration for the cache when it's present
-     * @param CacheItemPoolInterface $cache A cache implementation, may be
+     * @param callable|null $httpHandler callback which delivers psr7 request
+     * @param array<mixed>|null $cacheConfig configuration for the cache when it's present
+     * @param CacheItemPoolInterface|null $cache A cache implementation, may be
      *        provided if you have one already available for use.
      * @return ProxyAuthTokenMiddleware
      * @throws DomainException if no implementation can be obtained.
      */
     public static function getProxyIdTokenMiddleware(
         $targetAudience,
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $creds = self::getIdTokenCredentials($targetAudience, $httpHandler, $cacheConfig, $cache);
 
@@ -266,9 +266,9 @@ class ApplicationDefaultCredentials
      * token.
      *
      * @param string $targetAudience The audience for the ID token.
-     * @param callable $httpHandler callback which delivers psr7 request
-     * @param array<mixed> $cacheConfig configuration for the cache when it's present
-     * @param CacheItemPoolInterface $cache A cache implementation, may be
+     * @param callable|null $httpHandler callback which delivers psr7 request
+     * @param array<mixed>|null $cacheConfig configuration for the cache when it's present
+     * @param CacheItemPoolInterface|null $cache A cache implementation, may be
      *        provided if you have one already available for use.
      * @return FetchAuthTokenInterface
      * @throws DomainException if no implementation can be obtained.
@@ -276,9 +276,9 @@ class ApplicationDefaultCredentials
      */
     public static function getIdTokenCredentials(
         $targetAudience,
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $creds = null;
         $jsonKey = CredentialsLoader::fromEnv()
@@ -334,15 +334,15 @@ class ApplicationDefaultCredentials
     }
 
     /**
-     * @param callable $httpHandler
-     * @param array<mixed> $cacheConfig
-     * @param CacheItemPoolInterface $cache
+     * @param callable|null $httpHandler
+     * @param array<mixed>|null $cacheConfig
+     * @param CacheItemPoolInterface|null $cache
      * @return bool
      */
     private static function onGce(
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $gceCacheConfig = [];
         foreach (['lifetime', 'prefix'] as $key) {

--- a/src/CredentialSource/AwsNativeSource.php
+++ b/src/CredentialSource/AwsNativeSource.php
@@ -61,7 +61,7 @@ class AwsNativeSource implements ExternalAccountCredentialSourceInterface
         $this->imdsv2SessionTokenUrl = $imdsv2SessionTokenUrl;
     }
 
-    public function fetchSubjectToken(callable $httpHandler = null): string
+    public function fetchSubjectToken(?callable $httpHandler = null): string
     {
         if (is_null($httpHandler)) {
             $httpHandler = HttpHandlerFactory::build(HttpClientCache::getHttpClient());

--- a/src/CredentialSource/AwsNativeSource.php
+++ b/src/CredentialSource/AwsNativeSource.php
@@ -50,9 +50,9 @@ class AwsNativeSource implements ExternalAccountCredentialSourceInterface
     public function __construct(
         string $audience,
         string $regionalCredVerificationUrl,
-        string $regionUrl = null,
-        string $securityCredentialsUrl = null,
-        string $imdsv2SessionTokenUrl = null
+        ?string $regionUrl = null,
+        ?string $securityCredentialsUrl = null,
+        ?string $imdsv2SessionTokenUrl = null
     ) {
         $this->audience = $audience;
         $this->regionalCredVerificationUrl = $regionalCredVerificationUrl;

--- a/src/CredentialSource/ExecutableSource.php
+++ b/src/CredentialSource/ExecutableSource.php
@@ -88,12 +88,12 @@ class ExecutableSource implements ExternalAccountCredentialSourceInterface
 
     /**
      * @param string $command    The string command to run to get the subject token.
-     * @param string $outputFile
+     * @param string|null $outputFile
      */
     public function __construct(
         string $command,
         ?string $outputFile,
-        ExecutableHandler $executableHandler = null,
+        ?ExecutableHandler $executableHandler = null,
     ) {
         $this->command = $command;
         $this->outputFile = $outputFile;

--- a/src/CredentialSource/ExecutableSource.php
+++ b/src/CredentialSource/ExecutableSource.php
@@ -113,12 +113,12 @@ class ExecutableSource implements ExternalAccountCredentialSourceInterface
     }
 
     /**
-     * @param callable $httpHandler unused.
+     * @param callable|null $httpHandler unused.
      * @return string
      * @throws RuntimeException if the executable is not allowed to run.
      * @throws ExecutableResponseError if the executable response is invalid.
      */
-    public function fetchSubjectToken(callable $httpHandler = null): string
+    public function fetchSubjectToken(?callable $httpHandler = null): string
     {
         // Check if the executable is allowed to run.
         if (getenv(self::GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES) !== '1') {

--- a/src/CredentialSource/FileSource.php
+++ b/src/CredentialSource/FileSource.php
@@ -53,7 +53,7 @@ class FileSource implements ExternalAccountCredentialSourceInterface
         $this->subjectTokenFieldName = $subjectTokenFieldName;
     }
 
-    public function fetchSubjectToken(callable $httpHandler = null): string
+    public function fetchSubjectToken(?callable $httpHandler = null): string
     {
         $contents = file_get_contents($this->file);
         if ($this->format === 'json') {

--- a/src/CredentialSource/FileSource.php
+++ b/src/CredentialSource/FileSource.php
@@ -31,15 +31,15 @@ class FileSource implements ExternalAccountCredentialSourceInterface
     private ?string $subjectTokenFieldName;
 
     /**
-     * @param string $file                  The file to read the subject token from.
-     * @param string $format                The format of the token in the file. Can be null or "json".
-     * @param string $subjectTokenFieldName The name of the field containing the token in the file. This is required
-     *                                      when format is "json".
+     * @param string $file                       The file to read the subject token from.
+     * @param string|null $format                The format of the token in the file. Can be null or "json".
+     * @param string|null $subjectTokenFieldName The name of the field containing the token in the file. This is required
+     *                                           when format is "json".
      */
     public function __construct(
         string $file,
-        string $format = null,
-        string $subjectTokenFieldName = null
+        ?string $format = null,
+        ?string $subjectTokenFieldName = null
     ) {
         $this->file = $file;
 

--- a/src/CredentialSource/UrlSource.php
+++ b/src/CredentialSource/UrlSource.php
@@ -64,7 +64,7 @@ class UrlSource implements ExternalAccountCredentialSourceInterface
         $this->headers = $headers;
     }
 
-    public function fetchSubjectToken(callable $httpHandler = null): string
+    public function fetchSubjectToken(?callable $httpHandler = null): string
     {
         if (is_null($httpHandler)) {
             $httpHandler = HttpHandlerFactory::build(HttpClientCache::getHttpClient());

--- a/src/CredentialSource/UrlSource.php
+++ b/src/CredentialSource/UrlSource.php
@@ -39,17 +39,17 @@ class UrlSource implements ExternalAccountCredentialSourceInterface
     private ?array $headers;
 
     /**
-     * @param string $url                   The URL to fetch the subject token from.
-     * @param string $format                The format of the token in the response. Can be null or "json".
-     * @param string $subjectTokenFieldName The name of the field containing the token in the response. This is required
+     * @param string $url                        The URL to fetch the subject token from.
+     * @param string|null $format                The format of the token in the response. Can be null or "json".
+     * @param string|null $subjectTokenFieldName The name of the field containing the token in the response. This is required
      *                                      when format is "json".
-     * @param array<string, string|string[]> $headers Request headers to send in with the request to the URL.
+     * @param array<string, string|string[]>|null $headers Request headers to send in with the request to the URL.
      */
     public function __construct(
         string $url,
-        string $format = null,
-        string $subjectTokenFieldName = null,
-        array $headers = null
+        ?string $format = null,
+        ?string $subjectTokenFieldName = null,
+        ?array $headers = null
     ) {
         $this->url = $url;
 

--- a/src/Credentials/AppIdentityCredentials.php
+++ b/src/Credentials/AppIdentityCredentials.php
@@ -116,7 +116,7 @@ class AppIdentityCredentials extends CredentialsLoader implements
      * As the AppIdentityService uses protobufs to fetch the access token,
      * the GuzzleHttp\ClientInterface instance passed in will not be used.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @return array<mixed> {
      *     A set of auth related metadata, containing the following
      *
@@ -124,7 +124,7 @@ class AppIdentityCredentials extends CredentialsLoader implements
      *     @type string $expiration_time
      * }
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         try {
             $this->checkAppEngineContext();
@@ -161,10 +161,10 @@ class AppIdentityCredentials extends CredentialsLoader implements
      *
      * Returns null if AppIdentityService is unavailable.
      *
-     * @param callable $httpHandler Not used by this type.
+     * @param callable|null $httpHandler Not used by this type.
      * @return string|null
      */
-    public function getProjectId(callable $httpHandler = null)
+    public function getProjectId(?callable $httpHandler = null)
     {
         try {
             $this->checkAppEngineContext();
@@ -181,11 +181,11 @@ class AppIdentityCredentials extends CredentialsLoader implements
      *
      * Subsequent calls to this method will return a cached value.
      *
-     * @param callable $httpHandler Not used in this implementation.
+     * @param callable|null $httpHandler Not used in this implementation.
      * @return string
      * @throws \Exception If AppEngine SDK or mock is not available.
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(?callable $httpHandler = null)
     {
         $this->checkAppEngineContext();
 

--- a/src/Credentials/ExternalAccountCredentials.php
+++ b/src/Credentials/ExternalAccountCredentials.php
@@ -211,7 +211,7 @@ class ExternalAccountCredentials implements
 
     /**
      * @param string $stsToken
-     * @param callable $httpHandler
+     * @param callable|null $httpHandler
      *
      * @return array<mixed> {
      *     A set of auth related metadata, containing the following
@@ -220,7 +220,7 @@ class ExternalAccountCredentials implements
      *     @type int $expires_at
      * }
      */
-    private function getImpersonatedAccessToken(string $stsToken, callable $httpHandler = null): array
+    private function getImpersonatedAccessToken(string $stsToken, ?callable $httpHandler = null): array
     {
         if (!isset($this->serviceAccountImpersonationUrl)) {
             throw new InvalidArgumentException(
@@ -251,7 +251,7 @@ class ExternalAccountCredentials implements
     }
 
     /**
-     * @param callable $httpHandler
+     * @param callable|null $httpHandler
      *
      * @return array<mixed> {
      *     A set of auth related metadata, containing the following
@@ -263,7 +263,7 @@ class ExternalAccountCredentials implements
      *     @type string $token_type (identity pool only)
      * }
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         $stsToken = $this->auth->fetchAuthToken($httpHandler);
 
@@ -325,13 +325,13 @@ class ExternalAccountCredentials implements
     /**
      * Get the project ID.
      *
-     * @param callable $httpHandler Callback which delivers psr7 request
-     * @param string $accessToken The access token to use to sign the blob. If
+     * @param callable|null $httpHandler Callback which delivers psr7 request
+     * @param string|null $accessToken The access token to use to sign the blob. If
      *        provided, saves a call to the metadata server for a new access
      *        token. **Defaults to** `null`.
      * @return string|null
      */
-    public function getProjectId(callable $httpHandler = null, string $accessToken = null)
+    public function getProjectId(?callable $httpHandler = null, ?string $accessToken = null)
     {
         if (isset($this->projectId)) {
             return $this->projectId;

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -199,7 +199,7 @@ class GCECredentials extends CredentialsLoader implements
     private ?string $universeDomain;
 
     /**
-     * @param Iam $iam [optional] An IAM instance.
+     * @param Iam|null $iam [optional] An IAM instance.
      * @param string|string[] $scope [optional] the scope of the access request,
      *        expressed either as an array or as a space-delimited string.
      * @param string $targetAudience [optional] The audience for the ID token.
@@ -207,16 +207,16 @@ class GCECredentials extends CredentialsLoader implements
      *   charges associated with the request.
      * @param string $serviceAccountIdentity [optional] Specify a service
      *   account identity name to use instead of "default".
-     * @param string $universeDomain [optional] Specify a universe domain to use
+     * @param string|null $universeDomain [optional] Specify a universe domain to use
      *   instead of fetching one from the metadata server.
      */
     public function __construct(
-        Iam $iam = null,
+        ?Iam $iam = null,
         $scope = null,
         $targetAudience = null,
         $quotaProject = null,
         $serviceAccountIdentity = null,
-        string $universeDomain = null
+        ?string $universeDomain = null
     ) {
         $this->iam = $iam;
 

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -355,10 +355,10 @@ class GCECredentials extends CredentialsLoader implements
      * host.
      * If $httpHandler is not specified a the default HttpHandler is used.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @return bool True if this a GCEInstance, false otherwise
      */
-    public static function onGce(callable $httpHandler = null)
+    public static function onGce(?callable $httpHandler = null)
     {
         $httpHandler = $httpHandler
             ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());
@@ -441,7 +441,7 @@ class GCECredentials extends CredentialsLoader implements
      * Fetches the auth tokens from the GCE metadata host if it is available.
      * If $httpHandler is not specified a the default HttpHandler is used.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      *
      * @return array<mixed> {
      *     A set of auth related metadata, based on the token type.
@@ -453,7 +453,7 @@ class GCECredentials extends CredentialsLoader implements
      * }
      * @throws \Exception
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         $httpHandler = $httpHandler
             ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());
@@ -524,10 +524,10 @@ class GCECredentials extends CredentialsLoader implements
      *
      * Subsequent calls will return a cached value.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @return string
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(?callable $httpHandler = null)
     {
         if ($this->clientName) {
             return $this->clientName;
@@ -558,10 +558,10 @@ class GCECredentials extends CredentialsLoader implements
      *
      * Returns null if called outside GCE.
      *
-     * @param callable $httpHandler Callback which delivers psr7 request
+     * @param callable|null $httpHandler Callback which delivers psr7 request
      * @return string|null
      */
-    public function getProjectId(callable $httpHandler = null)
+    public function getProjectId(?callable $httpHandler = null)
     {
         if ($this->projectId) {
             return $this->projectId;
@@ -586,10 +586,10 @@ class GCECredentials extends CredentialsLoader implements
     /**
      * Fetch the default universe domain from the metadata server.
      *
-     * @param callable $httpHandler Callback which delivers psr7 request
+     * @param callable|null $httpHandler Callback which delivers psr7 request
      * @return string
      */
-    public function getUniverseDomain(callable $httpHandler = null): string
+    public function getUniverseDomain(?callable $httpHandler = null): string
     {
         if (null !== $this->universeDomain) {
             return $this->universeDomain;

--- a/src/Credentials/IAMCredentials.php
+++ b/src/Credentials/IAMCredentials.php
@@ -71,7 +71,7 @@ class IAMCredentials
      *
      * @param array<mixed> $metadata metadata hashmap
      * @param string $unusedAuthUri optional auth uri
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      *        Note: this param is unused here, only included here for
      *        consistency with other credentials class
      *
@@ -80,7 +80,7 @@ class IAMCredentials
     public function updateMetadata(
         $metadata,
         $unusedAuthUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     ) {
         $metadata_copy = $metadata;
         $metadata_copy[self::SELECTOR_KEY] = $this->selector;

--- a/src/Credentials/ImpersonatedServiceAccountCredentials.php
+++ b/src/Credentials/ImpersonatedServiceAccountCredentials.php
@@ -103,13 +103,13 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
      * @param callable|null $unusedHttpHandler not used by this credentials type.
      * @return string Token issuer email
      */
-    public function getClientName(callable $unusedHttpHandler = null)
+    public function getClientName(?callable $unusedHttpHandler = null)
     {
         return $this->impersonatedServiceAccountName;
     }
 
     /**
-     * @param callable $httpHandler
+     * @param callable|null $httpHandler
      *
      * @return array<mixed> {
      *     A set of auth related metadata, containing the following
@@ -121,7 +121,7 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
      *     @type string $id_token
      * }
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         // We don't support id token endpoint requests as of now for Impersonated Cred
         return $this->sourceCredentials->fetchAuthToken(

--- a/src/Credentials/InsecureCredentials.php
+++ b/src/Credentials/InsecureCredentials.php
@@ -36,10 +36,10 @@ class InsecureCredentials implements FetchAuthTokenInterface
     /**
      * Fetches the auth token. In this case it returns an empty string.
      *
-     * @param callable $httpHandler
+     * @param callable|null $httpHandler
      * @return array{access_token:string} A set of auth related metadata
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         return $this->token;
     }

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -189,7 +189,7 @@ class ServiceAccountCredentials extends CredentialsLoader implements
     }
 
     /**
-     * @param callable $httpHandler
+     * @param callable|null $httpHandler
      *
      * @return array<mixed> {
      *     A set of auth related metadata, containing the following
@@ -199,7 +199,7 @@ class ServiceAccountCredentials extends CredentialsLoader implements
      *     @type string $token_type
      * }
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         if ($this->useSelfSignedJwt()) {
             $jwtCreds = $this->createJwtAccessCredentials();
@@ -258,10 +258,10 @@ class ServiceAccountCredentials extends CredentialsLoader implements
      *
      * Returns null if the project ID does not exist in the keyfile.
      *
-     * @param callable $httpHandler Not used by this credentials type.
+     * @param callable|null $httpHandler Not used by this credentials type.
      * @return string|null
      */
-    public function getProjectId(callable $httpHandler = null)
+    public function getProjectId(?callable $httpHandler = null)
     {
         return $this->projectId;
     }
@@ -335,10 +335,10 @@ class ServiceAccountCredentials extends CredentialsLoader implements
      *
      * In this case, it returns the keyfile's client_email key.
      *
-     * @param callable $httpHandler Not used by this credentials type.
+     * @param callable|null $httpHandler Not used by this credentials type.
      * @return string
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(?callable $httpHandler = null)
     {
         return $this->auth->getIssuer();
     }

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -271,13 +271,13 @@ class ServiceAccountCredentials extends CredentialsLoader implements
      *
      * @param array<mixed> $metadata metadata hashmap
      * @param string $authUri optional auth uri
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @return array<mixed> updated metadata hashmap
      */
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     ) {
         // scope exists. use oauth implementation
         if (!$this->useSelfSignedJwt()) {

--- a/src/Credentials/ServiceAccountJwtAccessCredentials.php
+++ b/src/Credentials/ServiceAccountJwtAccessCredentials.php
@@ -114,13 +114,13 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
      *
      * @param array<mixed> $metadata metadata hashmap
      * @param string $authUri optional auth uri
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @return array<mixed> updated metadata hashmap
      */
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     ) {
         $scope = $this->auth->getScope();
         if (empty($authUri) && empty($scope)) {

--- a/src/Credentials/ServiceAccountJwtAccessCredentials.php
+++ b/src/Credentials/ServiceAccountJwtAccessCredentials.php
@@ -135,11 +135,11 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
     /**
      * Implements FetchAuthTokenInterface#fetchAuthToken.
      *
-     * @param callable $httpHandler
+     * @param callable|null $httpHandler
      *
      * @return null|array{access_token:string} A set of auth related metadata
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         $audience = $this->auth->getAudience();
         $scope = $this->auth->getScope();
@@ -196,10 +196,10 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
      *
      * Returns null if the project ID does not exist in the keyfile.
      *
-     * @param callable $httpHandler Not used by this credentials type.
+     * @param callable|null $httpHandler Not used by this credentials type.
      * @return string|null
      */
-    public function getProjectId(callable $httpHandler = null)
+    public function getProjectId(?callable $httpHandler = null)
     {
         return $this->projectId;
     }
@@ -209,10 +209,10 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
      *
      * In this case, it returns the keyfile's client_email key.
      *
-     * @param callable $httpHandler Not used by this credentials type.
+     * @param callable|null $httpHandler Not used by this credentials type.
      * @return string
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(?callable $httpHandler = null)
     {
         return $this->auth->getIssuer();
     }

--- a/src/Credentials/UserRefreshCredentials.php
+++ b/src/Credentials/UserRefreshCredentials.php
@@ -104,7 +104,7 @@ class UserRefreshCredentials extends CredentialsLoader implements GetQuotaProjec
     }
 
     /**
-     * @param callable $httpHandler
+     * @param callable|null $httpHandler
      * @param array<mixed> $metricsHeader [optional] Metrics headers to be inserted
      *     into the token endpoint request present.
      *     This could be passed from ImersonatedServiceAccountCredentials as it uses
@@ -120,7 +120,7 @@ class UserRefreshCredentials extends CredentialsLoader implements GetQuotaProjec
      *     @type string $id_token
      * }
      */
-    public function fetchAuthToken(callable $httpHandler = null, array $metricsHeader = [])
+    public function fetchAuthToken(?callable $httpHandler = null, array $metricsHeader = [])
     {
         // We don't support id token endpoint requests as of now for User Cred
         return $this->auth->fetchAuthToken(

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -165,15 +165,15 @@ abstract class CredentialsLoader implements
      *
      * @param FetchAuthTokenInterface $fetcher is used to fetch the auth token
      * @param array<mixed> $httpClientOptions (optional) Array of request options to apply.
-     * @param callable $httpHandler (optional) http client to fetch the token.
-     * @param callable $tokenCallback (optional) function to be called when a new token is fetched.
+     * @param callable|null $httpHandler (optional) http client to fetch the token.
+     * @param callable|null $tokenCallback (optional) function to be called when a new token is fetched.
      * @return \GuzzleHttp\Client
      */
     public static function makeHttpClient(
         FetchAuthTokenInterface $fetcher,
         array $httpClientOptions = [],
-        callable $httpHandler = null,
-        callable $tokenCallback = null
+        ?callable $httpHandler = null,
+        ?callable $tokenCallback = null
     ) {
         $middleware = new Middleware\AuthTokenMiddleware(
             $fetcher,

--- a/src/ExternalAccountCredentialSourceInterface.php
+++ b/src/ExternalAccountCredentialSourceInterface.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Copyright 2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,6 @@ namespace Google\Auth;
 
 interface ExternalAccountCredentialSourceInterface
 {
-    public function fetchSubjectToken(callable $httpHandler = null): string;
+    public function fetchSubjectToken(?callable $httpHandler = null): string;
     public function getCacheKey(): ?string;
 }

--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -76,11 +76,11 @@ class FetchAuthTokenCache implements
      * Checks the cache for a valid auth token and fetches the auth tokens
      * from the supplied fetcher.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @return array<mixed> the response
      * @throws \Exception
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         if ($cached = $this->fetchAuthTokenFromCache()) {
             return $cached;
@@ -112,10 +112,10 @@ class FetchAuthTokenCache implements
     /**
      * Get the client name from the fetcher.
      *
-     * @param callable $httpHandler An HTTP handler to deliver PSR7 requests.
+     * @param callable|null $httpHandler An HTTP handler to deliver PSR7 requests.
      * @return string
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(?callable $httpHandler = null)
     {
         if (!$this->fetcher instanceof SignBlobInterface) {
             throw new \RuntimeException(
@@ -176,15 +176,15 @@ class FetchAuthTokenCache implements
         return null;
     }
 
-    /*
+    /**
      * Get the Project ID from the fetcher.
      *
-     * @param callable $httpHandler Callback which delivers psr7 request
+     * @param callable|null $httpHandler Callback which delivers psr7 request
      * @return string|null
      * @throws \RuntimeException If the fetcher does not implement
      *     `Google\Auth\ProvidesProjectIdInterface`.
      */
-    public function getProjectId(callable $httpHandler = null)
+    public function getProjectId(?callable $httpHandler = null)
     {
         if (!$this->fetcher instanceof ProjectIdProviderInterface) {
             throw new \RuntimeException(

--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -45,13 +45,13 @@ class FetchAuthTokenCache implements
 
     /**
      * @param FetchAuthTokenInterface $fetcher A credentials fetcher
-     * @param array<mixed> $cacheConfig Configuration for the cache
+     * @param array<mixed>|null $cacheConfig Configuration for the cache
      * @param CacheItemPoolInterface $cache
      */
     public function __construct(
         FetchAuthTokenInterface $fetcher,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $this->fetcher = $fetcher;
         $this->cache = $cache;
@@ -227,7 +227,7 @@ class FetchAuthTokenCache implements
      *
      * @param array<mixed> $metadata metadata hashmap
      * @param string $authUri optional auth uri
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @return array<mixed> updated metadata hashmap
      * @throws \RuntimeException If the fetcher does not implement
      *     `Google\Auth\UpdateMetadataInterface`.
@@ -235,7 +235,7 @@ class FetchAuthTokenCache implements
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     ) {
         if (!$this->fetcher instanceof UpdateMetadataInterface) {
             throw new \RuntimeException(

--- a/src/FetchAuthTokenInterface.php
+++ b/src/FetchAuthTokenInterface.php
@@ -25,10 +25,10 @@ interface FetchAuthTokenInterface
     /**
      * Fetches the auth tokens based on the current state.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @return array<mixed> a hash of auth tokens
      */
-    public function fetchAuthToken(callable $httpHandler = null);
+    public function fetchAuthToken(?callable $httpHandler = null);
 
     /**
      * Obtains a key that can used to cache the results of #fetchAuthToken.

--- a/src/GCECache.php
+++ b/src/GCECache.php
@@ -60,10 +60,10 @@ class GCECache
      * Caches the result of onGce so the metadata server is not called multiple
      * times.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @return bool True if this a GCEInstance, false otherwise
      */
-    public function onGce(callable $httpHandler = null)
+    public function onGce(?callable $httpHandler = null)
     {
         if (is_null($this->cache)) {
             return GCECredentials::onGce($httpHandler);

--- a/src/GCECache.php
+++ b/src/GCECache.php
@@ -46,8 +46,8 @@ class GCECache
      * @param CacheItemPoolInterface $cache
      */
     public function __construct(
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $this->cache = $cache;
         $this->cacheConfig = array_merge([

--- a/src/HttpHandler/HttpClientCache.php
+++ b/src/HttpHandler/HttpClientCache.php
@@ -37,7 +37,7 @@ class HttpClientCache
      * @param ClientInterface|null $client
      * @return void
      */
-    public static function setHttpClient(ClientInterface $client = null)
+    public static function setHttpClient(?ClientInterface $client = null)
     {
         self::$httpClient = $client;
     }

--- a/src/HttpHandler/HttpHandlerFactory.php
+++ b/src/HttpHandler/HttpHandlerFactory.php
@@ -27,11 +27,11 @@ class HttpHandlerFactory
     /**
      * Builds out a default http handler for the installed version of guzzle.
      *
-     * @param ClientInterface $client
+     * @param ClientInterface|null $client
      * @return Guzzle6HttpHandler|Guzzle7HttpHandler
      * @throws \Exception
      */
-    public static function build(ClientInterface $client = null)
+    public static function build(?ClientInterface $client = null)
     {
         if (is_null($client)) {
             $stack = null;

--- a/src/Iam.php
+++ b/src/Iam.php
@@ -45,10 +45,10 @@ class Iam
     private string $universeDomain;
 
     /**
-     * @param callable $httpHandler [optional] The HTTP Handler to send requests.
+     * @param callable|null $httpHandler [optional] The HTTP Handler to send requests.
      */
     public function __construct(
-        callable $httpHandler = null,
+        ?callable $httpHandler = null,
         string $universeDomain = GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN
     ) {
         $this->httpHandler = $httpHandler

--- a/src/Middleware/AuthTokenMiddleware.php
+++ b/src/Middleware/AuthTokenMiddleware.php
@@ -59,13 +59,13 @@ class AuthTokenMiddleware
      * Creates a new AuthTokenMiddleware.
      *
      * @param FetchAuthTokenInterface $fetcher is used to fetch the auth token
-     * @param callable $httpHandler (optional) callback which delivers psr7 request
-     * @param callable $tokenCallback (optional) function to be called when a new token is fetched.
+     * @param callable|null $httpHandler (optional) callback which delivers psr7 request
+     * @param callable|null $tokenCallback (optional) function to be called when a new token is fetched.
      */
     public function __construct(
         FetchAuthTokenInterface $fetcher,
-        callable $httpHandler = null,
-        callable $tokenCallback = null
+        ?callable $httpHandler = null,
+        ?callable $tokenCallback = null
     ) {
         $this->fetcher = $fetcher;
         $this->httpHandler = $httpHandler;

--- a/src/Middleware/ProxyAuthTokenMiddleware.php
+++ b/src/Middleware/ProxyAuthTokenMiddleware.php
@@ -53,13 +53,13 @@ class ProxyAuthTokenMiddleware
      * Creates a new ProxyAuthTokenMiddleware.
      *
      * @param FetchAuthTokenInterface $fetcher is used to fetch the auth token
-     * @param callable $httpHandler (optional) callback which delivers psr7 request
-     * @param callable $tokenCallback (optional) function to be called when a new token is fetched.
+     * @param callable|null $httpHandler (optional) callback which delivers psr7 request
+     * @param callable|null $tokenCallback (optional) function to be called when a new token is fetched.
      */
     public function __construct(
         FetchAuthTokenInterface $fetcher,
-        callable $httpHandler = null,
-        callable $tokenCallback = null
+        ?callable $httpHandler = null,
+        ?callable $tokenCallback = null
     ) {
         $this->fetcher = $fetcher;
         $this->httpHandler = $httpHandler;

--- a/src/Middleware/ScopedAccessTokenMiddleware.php
+++ b/src/Middleware/ScopedAccessTokenMiddleware.php
@@ -54,14 +54,14 @@ class ScopedAccessTokenMiddleware
      *
      * @param callable $tokenFunc a token generator function
      * @param array<string>|string $scopes the token authentication scopes
-     * @param array<mixed> $cacheConfig configuration for the cache when it's present
-     * @param CacheItemPoolInterface $cache an implementation of CacheItemPoolInterface
+     * @param array<mixed>|null $cacheConfig configuration for the cache when it's present
+     * @param CacheItemPoolInterface|null $cache an implementation of CacheItemPoolInterface
      */
     public function __construct(
         callable $tokenFunc,
         $scopes,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $this->tokenFunc = $tokenFunc;
         if (!(is_string($scopes) || is_array($scopes))) {

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -581,12 +581,12 @@ class OAuth2 implements FetchAuthTokenInterface
     /**
      * Generates a request for token credentials.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @param array<mixed> $headers [optional] Additional headers to pass to
      *        the token endpoint request.
      * @return RequestInterface the authorization Url.
      */
-    public function generateCredentialsRequest(callable $httpHandler = null, $headers = [])
+    public function generateCredentialsRequest(?callable $httpHandler = null, $headers = [])
     {
         $uri = $this->getTokenCredentialUri();
         if (is_null($uri)) {
@@ -661,12 +661,12 @@ class OAuth2 implements FetchAuthTokenInterface
     /**
      * Fetches the auth tokens based on the current state.
      *
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @param array<mixed> $headers [optional] If present, add these headers to the token
      *        endpoint request.
      * @return array<mixed> the response
      */
-    public function fetchAuthToken(callable $httpHandler = null, $headers = [])
+    public function fetchAuthToken(?callable $httpHandler = null, $headers = [])
     {
         if (is_null($httpHandler)) {
             $httpHandler = HttpHandlerFactory::build(HttpClientCache::getHttpClient());
@@ -1683,11 +1683,11 @@ class OAuth2 implements FetchAuthTokenInterface
      *
      * Alias of {@see Google\Auth\OAuth2::getClientId()}.
      *
-     * @param callable $httpHandler
+     * @param callable|null $httpHandler
      * @return string
      * @access private
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(?callable $httpHandler = null)
     {
         return $this->getClientId();
     }

--- a/src/ProjectIdProviderInterface.php
+++ b/src/ProjectIdProviderInterface.php
@@ -25,8 +25,8 @@ interface ProjectIdProviderInterface
     /**
      * Get the project ID.
      *
-     * @param callable $httpHandler Callback which delivers psr7 request
+     * @param callable|null $httpHandler Callback which delivers psr7 request
      * @return string|null
      */
-    public function getProjectId(callable $httpHandler = null);
+    public function getProjectId(?callable $httpHandler = null);
 }

--- a/src/SignBlobInterface.php
+++ b/src/SignBlobInterface.php
@@ -36,9 +36,9 @@ interface SignBlobInterface extends FetchAuthTokenInterface
     /**
      * Returns the current Client Name.
      *
-     * @param callable $httpHandler callback which delivers psr7 request, if
+     * @param callable|null $httpHandler callback which delivers psr7 request, if
      *     one is required to obtain a client name.
      * @return string
      */
-    public function getClientName(callable $httpHandler = null);
+    public function getClientName(?callable $httpHandler = null);
 }

--- a/src/UpdateMetadataInterface.php
+++ b/src/UpdateMetadataInterface.php
@@ -30,12 +30,12 @@ interface UpdateMetadataInterface
      *
      * @param array<mixed> $metadata metadata hashmap
      * @param string $authUri optional auth uri
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @return array<mixed> updated metadata hashmap
      */
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     );
 }

--- a/src/UpdateMetadataTrait.php
+++ b/src/UpdateMetadataTrait.php
@@ -44,13 +44,13 @@ trait UpdateMetadataTrait
      *
      * @param array<mixed> $metadata metadata hashmap
      * @param string $authUri optional auth uri
-     * @param callable $httpHandler callback which delivers psr7 request
+     * @param callable|null $httpHandler callback which delivers psr7 request
      * @return array<mixed> updated metadata hashmap
      */
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     ) {
         $metadata_copy = $metadata;
 

--- a/tests/CredentialSource/ExecutableSourceTest.php
+++ b/tests/CredentialSource/ExecutableSourceTest.php
@@ -89,7 +89,7 @@ class ExecutableSourceTest extends TestCase
         int $returnCode,
         string $output,
         string $expectedExceptionMessage,
-        string $outputFile = null
+        ?string $outputFile = null
     ) {
         $this->expectException(ExecutableResponseError::class);
         $this->expectExceptionMessage($expectedExceptionMessage);

--- a/tests/CredentialSource/FileSourceTest.php
+++ b/tests/CredentialSource/FileSourceTest.php
@@ -32,8 +32,8 @@ class FileSourceTest extends TestCase
     public function testFetchSubjectToken(
         string $filename,
         string $expectedToken,
-        string $format = null,
-        string $subjectTokenFieldName = null
+        ?string $format = null,
+        ?string $subjectTokenFieldName = null
     ) {
         $source = new FileSource($filename, $format, $subjectTokenFieldName);
         $subjectToken = $source->fetchSubjectToken();

--- a/tests/CredentialSource/UrlSourceTest.php
+++ b/tests/CredentialSource/UrlSourceTest.php
@@ -38,8 +38,8 @@ class UrlSourceTest extends TestCase
     public function testFetchSubjectToken(
         string $responseBody,
         string $expectedToken,
-        string $format = null,
-        string $subjectTokenFieldName = null
+        ?string $format = null,
+        ?string $subjectTokenFieldName = null
     ) {
         $handler = function (RequestInterface $request) use ($responseBody): ResponseInterface {
             $this->assertEquals('GET', $request->getMethod());

--- a/tests/CredentialsLoaderTest.php
+++ b/tests/CredentialsLoaderTest.php
@@ -163,7 +163,7 @@ class TestCredentialsLoader extends CredentialsLoader
         return 'test';
     }
 
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         return 'test';
     }


### PR DESCRIPTION
Changes for the following PHP RFC

RFC: Deprecate implicitly nullable parameter types
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types