### PR TITLE
fix: add PHP 8.4 compatibility to last release compatible with PHP 7.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
+                php: [ "7.4", "8.0", "8.1", "8.2", "8.3", "8.4" ]
         name: PHP ${{matrix.php }} Unit Test
         steps:
             - uses: actions/checkout@v4

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -69,8 +69,8 @@ class AccessToken
      * @param CacheItemPoolInterface $cache [optional] A PSR-6 compatible cache implementation.
      */
     public function __construct(
-        callable $httpHandler = null,
-        CacheItemPoolInterface $cache = null
+        ?callable $httpHandler = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $this->httpHandler = $httpHandler
             ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());

--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -89,9 +89,9 @@ class ApplicationDefaultCredentials
      */
     public static function getSubscriber(// @phpstan-ignore-line
         $scope = null,
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $creds = self::getCredentials($scope, $httpHandler, $cacheConfig, $cache);
 
@@ -119,9 +119,9 @@ class ApplicationDefaultCredentials
      */
     public static function getMiddleware(
         $scope = null,
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null,
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null,
         $quotaProject = null
     ) {
         $creds = self::getCredentials($scope, $httpHandler, $cacheConfig, $cache, $quotaProject);
@@ -152,12 +152,12 @@ class ApplicationDefaultCredentials
      */
     public static function getCredentials(
         $scope = null,
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null,
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null,
         $quotaProject = null,
         $defaultScope = null,
-        string $universeDomain = null
+        ?string $universeDomain = null
     ) {
         $creds = null;
         $jsonKey = CredentialsLoader::fromEnv()
@@ -224,9 +224,9 @@ class ApplicationDefaultCredentials
      */
     public static function getIdTokenMiddleware(
         $targetAudience,
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $creds = self::getIdTokenCredentials($targetAudience, $httpHandler, $cacheConfig, $cache);
 
@@ -251,9 +251,9 @@ class ApplicationDefaultCredentials
      */
     public static function getProxyIdTokenMiddleware(
         $targetAudience,
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $creds = self::getIdTokenCredentials($targetAudience, $httpHandler, $cacheConfig, $cache);
 
@@ -276,9 +276,9 @@ class ApplicationDefaultCredentials
      */
     public static function getIdTokenCredentials(
         $targetAudience,
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $creds = null;
         $jsonKey = CredentialsLoader::fromEnv()
@@ -340,9 +340,9 @@ class ApplicationDefaultCredentials
      * @return bool
      */
     private static function onGce(
-        callable $httpHandler = null,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?callable $httpHandler = null,
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $gceCacheConfig = [];
         foreach (['lifetime', 'prefix'] as $key) {

--- a/src/CredentialSource/AwsNativeSource.php
+++ b/src/CredentialSource/AwsNativeSource.php
@@ -50,9 +50,9 @@ class AwsNativeSource implements ExternalAccountCredentialSourceInterface
     public function __construct(
         string $audience,
         string $regionalCredVerificationUrl,
-        string $regionUrl = null,
-        string $securityCredentialsUrl = null,
-        string $imdsv2SessionTokenUrl = null
+        ?string $regionUrl = null,
+        ?string $securityCredentialsUrl = null,
+        ?string $imdsv2SessionTokenUrl = null
     ) {
         $this->audience = $audience;
         $this->regionalCredVerificationUrl = $regionalCredVerificationUrl;
@@ -61,7 +61,7 @@ class AwsNativeSource implements ExternalAccountCredentialSourceInterface
         $this->imdsv2SessionTokenUrl = $imdsv2SessionTokenUrl;
     }
 
-    public function fetchSubjectToken(callable $httpHandler = null): string
+    public function fetchSubjectToken(?callable $httpHandler = null): string
     {
         if (is_null($httpHandler)) {
             $httpHandler = HttpHandlerFactory::build(HttpClientCache::getHttpClient());

--- a/src/CredentialSource/FileSource.php
+++ b/src/CredentialSource/FileSource.php
@@ -38,8 +38,8 @@ class FileSource implements ExternalAccountCredentialSourceInterface
      */
     public function __construct(
         string $file,
-        string $format = null,
-        string $subjectTokenFieldName = null
+        ?string $format = null,
+        ?string $subjectTokenFieldName = null
     ) {
         $this->file = $file;
 
@@ -53,7 +53,7 @@ class FileSource implements ExternalAccountCredentialSourceInterface
         $this->subjectTokenFieldName = $subjectTokenFieldName;
     }
 
-    public function fetchSubjectToken(callable $httpHandler = null): string
+    public function fetchSubjectToken(?callable $httpHandler = null): string
     {
         $contents = file_get_contents($this->file);
         if ($this->format === 'json') {

--- a/src/CredentialSource/UrlSource.php
+++ b/src/CredentialSource/UrlSource.php
@@ -47,9 +47,9 @@ class UrlSource implements ExternalAccountCredentialSourceInterface
      */
     public function __construct(
         string $url,
-        string $format = null,
-        string $subjectTokenFieldName = null,
-        array $headers = null
+        ?string $format = null,
+        ?string $subjectTokenFieldName = null,
+        ?array $headers = null
     ) {
         $this->url = $url;
 
@@ -64,7 +64,7 @@ class UrlSource implements ExternalAccountCredentialSourceInterface
         $this->headers = $headers;
     }
 
-    public function fetchSubjectToken(callable $httpHandler = null): string
+    public function fetchSubjectToken(?callable $httpHandler = null): string
     {
         if (is_null($httpHandler)) {
             $httpHandler = HttpHandlerFactory::build(HttpClientCache::getHttpClient());

--- a/src/Credentials/AppIdentityCredentials.php
+++ b/src/Credentials/AppIdentityCredentials.php
@@ -124,7 +124,7 @@ class AppIdentityCredentials extends CredentialsLoader implements
      *     @type string $expiration_time
      * }
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         try {
             $this->checkAppEngineContext();
@@ -164,7 +164,7 @@ class AppIdentityCredentials extends CredentialsLoader implements
      * @param callable $httpHandler Not used by this type.
      * @return string|null
      */
-    public function getProjectId(callable $httpHandler = null)
+    public function getProjectId(?callable $httpHandler = null)
     {
         try {
             $this->checkAppEngineContext();
@@ -185,7 +185,7 @@ class AppIdentityCredentials extends CredentialsLoader implements
      * @return string
      * @throws \Exception If AppEngine SDK or mock is not available.
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(?callable $httpHandler = null)
     {
         $this->checkAppEngineContext();
 

--- a/src/Credentials/ExternalAccountCredentials.php
+++ b/src/Credentials/ExternalAccountCredentials.php
@@ -188,7 +188,7 @@ class ExternalAccountCredentials implements
      *     @type int $expires_at
      * }
      */
-    private function getImpersonatedAccessToken(string $stsToken, callable $httpHandler = null): array
+    private function getImpersonatedAccessToken(string $stsToken, ?callable $httpHandler = null): array
     {
         if (!isset($this->serviceAccountImpersonationUrl)) {
             throw new InvalidArgumentException(
@@ -231,7 +231,7 @@ class ExternalAccountCredentials implements
      *     @type string $token_type (identity pool only)
      * }
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         $stsToken = $this->auth->fetchAuthToken($httpHandler);
 
@@ -281,7 +281,7 @@ class ExternalAccountCredentials implements
      *        token. **Defaults to** `null`.
      * @return string|null
      */
-    public function getProjectId(callable $httpHandler = null, string $accessToken = null)
+    public function getProjectId(?callable $httpHandler = null, ?string $accessToken = null)
     {
         if (isset($this->projectId)) {
             return $this->projectId;

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -192,12 +192,12 @@ class GCECredentials extends CredentialsLoader implements
      *   instead of fetching one from the metadata server.
      */
     public function __construct(
-        Iam $iam = null,
+        ?Iam $iam = null,
         $scope = null,
         $targetAudience = null,
         $quotaProject = null,
         $serviceAccountIdentity = null,
-        string $universeDomain = null
+        ?string $universeDomain = null
     ) {
         $this->iam = $iam;
 
@@ -339,7 +339,7 @@ class GCECredentials extends CredentialsLoader implements
      * @param callable $httpHandler callback which delivers psr7 request
      * @return bool True if this a GCEInstance, false otherwise
      */
-    public static function onGce(callable $httpHandler = null)
+    public static function onGce(?callable $httpHandler = null)
     {
         $httpHandler = $httpHandler
             ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());
@@ -408,7 +408,7 @@ class GCECredentials extends CredentialsLoader implements
      * }
      * @throws \Exception
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         $httpHandler = $httpHandler
             ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());
@@ -474,7 +474,7 @@ class GCECredentials extends CredentialsLoader implements
      * @param callable $httpHandler callback which delivers psr7 request
      * @return string
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(?callable $httpHandler = null)
     {
         if ($this->clientName) {
             return $this->clientName;
@@ -508,7 +508,7 @@ class GCECredentials extends CredentialsLoader implements
      * @param callable $httpHandler Callback which delivers psr7 request
      * @return string|null
      */
-    public function getProjectId(callable $httpHandler = null)
+    public function getProjectId(?callable $httpHandler = null)
     {
         if ($this->projectId) {
             return $this->projectId;
@@ -536,7 +536,7 @@ class GCECredentials extends CredentialsLoader implements
      * @param callable $httpHandler Callback which delivers psr7 request
      * @return string
      */
-    public function getUniverseDomain(callable $httpHandler = null): string
+    public function getUniverseDomain(?callable $httpHandler = null): string
     {
         if (null !== $this->universeDomain) {
             return $this->universeDomain;

--- a/src/Credentials/IAMCredentials.php
+++ b/src/Credentials/IAMCredentials.php
@@ -80,7 +80,7 @@ class IAMCredentials
     public function updateMetadata(
         $metadata,
         $unusedAuthUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     ) {
         $metadata_copy = $metadata;
         $metadata_copy[self::SELECTOR_KEY] = $this->selector;

--- a/src/Credentials/ImpersonatedServiceAccountCredentials.php
+++ b/src/Credentials/ImpersonatedServiceAccountCredentials.php
@@ -101,7 +101,7 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
      * @param callable|null $unusedHttpHandler not used by this credentials type.
      * @return string Token issuer email
      */
-    public function getClientName(callable $unusedHttpHandler = null)
+    public function getClientName(?callable $unusedHttpHandler = null)
     {
         return $this->impersonatedServiceAccountName;
     }
@@ -119,7 +119,7 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
      *     @type string $id_token
      * }
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         return $this->sourceCredentials->fetchAuthToken($httpHandler);
     }

--- a/src/Credentials/InsecureCredentials.php
+++ b/src/Credentials/InsecureCredentials.php
@@ -39,7 +39,7 @@ class InsecureCredentials implements FetchAuthTokenInterface
      * @param callable $httpHandler
      * @return array{access_token:string} A set of auth related metadata
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         return $this->token;
     }

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -192,7 +192,7 @@ class ServiceAccountCredentials extends CredentialsLoader implements
      *     @type string $token_type
      * }
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         if ($this->useSelfSignedJwt()) {
             $jwtCreds = $this->createJwtAccessCredentials();
@@ -242,7 +242,7 @@ class ServiceAccountCredentials extends CredentialsLoader implements
      * @param callable $httpHandler Not used by this credentials type.
      * @return string|null
      */
-    public function getProjectId(callable $httpHandler = null)
+    public function getProjectId(?callable $httpHandler = null)
     {
         return $this->projectId;
     }
@@ -258,7 +258,7 @@ class ServiceAccountCredentials extends CredentialsLoader implements
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     ) {
         // scope exists. use oauth implementation
         if (!$this->useSelfSignedJwt()) {
@@ -319,7 +319,7 @@ class ServiceAccountCredentials extends CredentialsLoader implements
      * @param callable $httpHandler Not used by this credentials type.
      * @return string
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(?callable $httpHandler = null)
     {
         return $this->auth->getIssuer();
     }

--- a/src/Credentials/ServiceAccountJwtAccessCredentials.php
+++ b/src/Credentials/ServiceAccountJwtAccessCredentials.php
@@ -113,7 +113,7 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     ) {
         $scope = $this->auth->getScope();
         if (empty($authUri) && empty($scope)) {
@@ -132,7 +132,7 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
      *
      * @return null|array{access_token:string} A set of auth related metadata
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         $audience = $this->auth->getAudience();
         $scope = $this->auth->getScope();
@@ -182,7 +182,7 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
      * @param callable $httpHandler Not used by this credentials type.
      * @return string|null
      */
-    public function getProjectId(callable $httpHandler = null)
+    public function getProjectId(?callable $httpHandler = null)
     {
         return $this->projectId;
     }
@@ -195,7 +195,7 @@ class ServiceAccountJwtAccessCredentials extends CredentialsLoader implements
      * @param callable $httpHandler Not used by this credentials type.
      * @return string
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(?callable $httpHandler = null)
     {
         return $this->auth->getIssuer();
     }

--- a/src/Credentials/UserRefreshCredentials.php
+++ b/src/Credentials/UserRefreshCredentials.php
@@ -109,7 +109,7 @@ class UserRefreshCredentials extends CredentialsLoader implements GetQuotaProjec
      *     @type string $id_token
      * }
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         return $this->auth->fetchAuthToken($httpHandler);
     }

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -172,8 +172,8 @@ abstract class CredentialsLoader implements
     public static function makeHttpClient(
         FetchAuthTokenInterface $fetcher,
         array $httpClientOptions = [],
-        callable $httpHandler = null,
-        callable $tokenCallback = null
+        ?callable $httpHandler = null,
+        ?callable $tokenCallback = null
     ) {
         $middleware = new Middleware\AuthTokenMiddleware(
             $fetcher,

--- a/src/ExternalAccountCredentialSourceInterface.php
+++ b/src/ExternalAccountCredentialSourceInterface.php
@@ -19,5 +19,5 @@ namespace Google\Auth;
 
 interface ExternalAccountCredentialSourceInterface
 {
-    public function fetchSubjectToken(callable $httpHandler = null): string;
+    public function fetchSubjectToken(?callable $httpHandler = null): string;
 }

--- a/src/FetchAuthTokenCache.php
+++ b/src/FetchAuthTokenCache.php
@@ -50,8 +50,8 @@ class FetchAuthTokenCache implements
      */
     public function __construct(
         FetchAuthTokenInterface $fetcher,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $this->fetcher = $fetcher;
         $this->cache = $cache;
@@ -80,7 +80,7 @@ class FetchAuthTokenCache implements
      * @return array<mixed> the response
      * @throws \Exception
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         if ($cached = $this->fetchAuthTokenFromCache()) {
             return $cached;
@@ -115,7 +115,7 @@ class FetchAuthTokenCache implements
      * @param callable $httpHandler An HTTP handler to deliver PSR7 requests.
      * @return string
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(?callable $httpHandler = null)
     {
         if (!$this->fetcher instanceof SignBlobInterface) {
             throw new \RuntimeException(
@@ -184,7 +184,7 @@ class FetchAuthTokenCache implements
      * @throws \RuntimeException If the fetcher does not implement
      *     `Google\Auth\ProvidesProjectIdInterface`.
      */
-    public function getProjectId(callable $httpHandler = null)
+    public function getProjectId(?callable $httpHandler = null)
     {
         if (!$this->fetcher instanceof ProjectIdProviderInterface) {
             throw new \RuntimeException(
@@ -235,7 +235,7 @@ class FetchAuthTokenCache implements
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     ) {
         if (!$this->fetcher instanceof UpdateMetadataInterface) {
             throw new \RuntimeException(

--- a/src/FetchAuthTokenInterface.php
+++ b/src/FetchAuthTokenInterface.php
@@ -28,7 +28,7 @@ interface FetchAuthTokenInterface
      * @param callable $httpHandler callback which delivers psr7 request
      * @return array<mixed> a hash of auth tokens
      */
-    public function fetchAuthToken(callable $httpHandler = null);
+    public function fetchAuthToken(?callable $httpHandler = null);
 
     /**
      * Obtains a key that can used to cache the results of #fetchAuthToken.

--- a/src/GCECache.php
+++ b/src/GCECache.php
@@ -46,8 +46,8 @@ class GCECache
      * @param CacheItemPoolInterface $cache
      */
     public function __construct(
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $this->cache = $cache;
         $this->cacheConfig = array_merge([
@@ -63,7 +63,7 @@ class GCECache
      * @param callable $httpHandler callback which delivers psr7 request
      * @return bool True if this a GCEInstance, false otherwise
      */
-    public function onGce(callable $httpHandler = null)
+    public function onGce(?callable $httpHandler = null)
     {
         if (is_null($this->cache)) {
             return GCECredentials::onGce($httpHandler);

--- a/src/HttpHandler/HttpClientCache.php
+++ b/src/HttpHandler/HttpClientCache.php
@@ -37,7 +37,7 @@ class HttpClientCache
      * @param ClientInterface|null $client
      * @return void
      */
-    public static function setHttpClient(ClientInterface $client = null)
+    public static function setHttpClient(?ClientInterface $client = null)
     {
         self::$httpClient = $client;
     }

--- a/src/HttpHandler/HttpHandlerFactory.php
+++ b/src/HttpHandler/HttpHandlerFactory.php
@@ -31,7 +31,7 @@ class HttpHandlerFactory
      * @return Guzzle6HttpHandler|Guzzle7HttpHandler
      * @throws \Exception
      */
-    public static function build(ClientInterface $client = null)
+    public static function build(?ClientInterface $client = null)
     {
         if (is_null($client)) {
             $stack = null;

--- a/src/Iam.php
+++ b/src/Iam.php
@@ -48,7 +48,7 @@ class Iam
      * @param callable $httpHandler [optional] The HTTP Handler to send requests.
      */
     public function __construct(
-        callable $httpHandler = null,
+        ?callable $httpHandler = null,
         string $universeDomain = GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN
     ) {
         $this->httpHandler = $httpHandler

--- a/src/Middleware/AuthTokenMiddleware.php
+++ b/src/Middleware/AuthTokenMiddleware.php
@@ -64,8 +64,8 @@ class AuthTokenMiddleware
      */
     public function __construct(
         FetchAuthTokenInterface $fetcher,
-        callable $httpHandler = null,
-        callable $tokenCallback = null
+        ?callable $httpHandler = null,
+        ?callable $tokenCallback = null
     ) {
         $this->fetcher = $fetcher;
         $this->httpHandler = $httpHandler;

--- a/src/Middleware/ProxyAuthTokenMiddleware.php
+++ b/src/Middleware/ProxyAuthTokenMiddleware.php
@@ -58,8 +58,8 @@ class ProxyAuthTokenMiddleware
      */
     public function __construct(
         FetchAuthTokenInterface $fetcher,
-        callable $httpHandler = null,
-        callable $tokenCallback = null
+        ?callable $httpHandler = null,
+        ?callable $tokenCallback = null
     ) {
         $this->fetcher = $fetcher;
         $this->httpHandler = $httpHandler;

--- a/src/Middleware/ScopedAccessTokenMiddleware.php
+++ b/src/Middleware/ScopedAccessTokenMiddleware.php
@@ -60,8 +60,8 @@ class ScopedAccessTokenMiddleware
     public function __construct(
         callable $tokenFunc,
         $scopes,
-        array $cacheConfig = null,
-        CacheItemPoolInterface $cache = null
+        ?array $cacheConfig = null,
+        ?CacheItemPoolInterface $cache = null
     ) {
         $this->tokenFunc = $tokenFunc;
         if (!(is_string($scopes) || is_array($scopes))) {

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -584,7 +584,7 @@ class OAuth2 implements FetchAuthTokenInterface
      * @param callable $httpHandler callback which delivers psr7 request
      * @return RequestInterface the authorization Url.
      */
-    public function generateCredentialsRequest(callable $httpHandler = null)
+    public function generateCredentialsRequest(?callable $httpHandler = null)
     {
         $uri = $this->getTokenCredentialUri();
         if (is_null($uri)) {
@@ -662,7 +662,7 @@ class OAuth2 implements FetchAuthTokenInterface
      * @param callable $httpHandler callback which delivers psr7 request
      * @return array<mixed> the response
      */
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         if (is_null($httpHandler)) {
             $httpHandler = HttpHandlerFactory::build(HttpClientCache::getHttpClient());
@@ -1661,7 +1661,7 @@ class OAuth2 implements FetchAuthTokenInterface
      * @return string
      * @access private
      */
-    public function getClientName(callable $httpHandler = null)
+    public function getClientName(?callable $httpHandler = null)
     {
         return $this->getClientId();
     }

--- a/src/ProjectIdProviderInterface.php
+++ b/src/ProjectIdProviderInterface.php
@@ -28,5 +28,5 @@ interface ProjectIdProviderInterface
      * @param callable $httpHandler Callback which delivers psr7 request
      * @return string|null
      */
-    public function getProjectId(callable $httpHandler = null);
+    public function getProjectId(?callable $httpHandler = null);
 }

--- a/src/SignBlobInterface.php
+++ b/src/SignBlobInterface.php
@@ -40,5 +40,5 @@ interface SignBlobInterface extends FetchAuthTokenInterface
      *     one is required to obtain a client name.
      * @return string
      */
-    public function getClientName(callable $httpHandler = null);
+    public function getClientName(?callable $httpHandler = null);
 }

--- a/src/UpdateMetadataInterface.php
+++ b/src/UpdateMetadataInterface.php
@@ -36,6 +36,6 @@ interface UpdateMetadataInterface
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     );
 }

--- a/src/UpdateMetadataTrait.php
+++ b/src/UpdateMetadataTrait.php
@@ -48,7 +48,7 @@ trait UpdateMetadataTrait
     public function updateMetadata(
         $metadata,
         $authUri = null,
-        callable $httpHandler = null
+        ?callable $httpHandler = null
     ) {
         if (isset($metadata[self::AUTH_METADATA_KEY])) {
             // Auth metadata has already been set

--- a/tests/CredentialSource/FileSourceTest.php
+++ b/tests/CredentialSource/FileSourceTest.php
@@ -32,8 +32,8 @@ class FileSourceTest extends TestCase
     public function testFetchSubjectToken(
         string $filename,
         string $expectedToken,
-        string $format = null,
-        string $subjectTokenFieldName = null
+        ?string $format = null,
+        ?string $subjectTokenFieldName = null
     ) {
         $source = new FileSource($filename, $format, $subjectTokenFieldName);
         $subjectToken = $source->fetchSubjectToken();

--- a/tests/CredentialSource/UrlSourceTest.php
+++ b/tests/CredentialSource/UrlSourceTest.php
@@ -38,8 +38,8 @@ class UrlSourceTest extends TestCase
     public function testFetchSubjectToken(
         string $responseBody,
         string $expectedToken,
-        string $format = null,
-        string $subjectTokenFieldName = null
+        ?string $format = null,
+        ?string $subjectTokenFieldName = null
     ) {
         $handler = function (RequestInterface $request) use ($responseBody): ResponseInterface {
             $this->assertEquals('GET', $request->getMethod());

--- a/tests/CredentialsLoaderTest.php
+++ b/tests/CredentialsLoaderTest.php
@@ -163,7 +163,7 @@ class TestCredentialsLoader extends CredentialsLoader
         return 'test';
     }
 
-    public function fetchAuthToken(callable $httpHandler = null)
+    public function fetchAuthToken(?callable $httpHandler = null)
     {
         return 'test';
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 require dirname(__DIR__) . '/vendor/autoload.php';
 date_default_timezone_set('UTC');
 


### PR DESCRIPTION
Ensures that the last `google/auth` release which was compatible with PHP 7.4 will be compatible with PHP 8.4 as well.

Once this is merged, we will tag this as `v1.37.2`

fixes https://github.com/googleapis/google-auth-library-php/issues/590