### PR TITLE
fix: minor changes to allow for refdoc regeneration

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,0 +1,7 @@
+{
+    "language": "php",
+    "distribution_name": "google/auth",
+    "release_level": "stable",
+    "client_documentation": "https://cloud.google.com/php/docs/reference/auth/latest",
+    "library_type": "CORE"
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "library",
   "description": "Google Auth Library for PHP",
   "keywords": ["google", "oauth2", "authentication"],
-  "homepage": "http://github.com/google/google-auth-library-php",
+  "homepage": "https://github.com/google/google-auth-library-php",
   "license": "Apache-2.0",
   "support": {
     "docs": "https://googleapis.github.io/google-auth-library-php/main/"


### PR DESCRIPTION
similar to https://github.com/googleapis/gax-php/pull/589, but for auth. Will allow `google/auth` to be added to cloud refdocs

see https://github.com/googleapis/google-cloud-php/pull/8047