### PR TITLE
chore: remove server superglobal support

### DIFF
--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -295,6 +295,6 @@ abstract class CredentialsLoader implements
 
     private static function getEnv(string $env): mixed
     {
-        return getenv($env) ?: $_SERVER[$env] ?? $_ENV[$env] ?? null;
+        return getenv($env) ?: $_ENV[$env] ?? null;
     }
 }

--- a/tests/CredentialsLoaderTest.php
+++ b/tests/CredentialsLoaderTest.php
@@ -171,19 +171,6 @@ class CredentialsLoaderTest extends TestCase
     /**
      * @runInSeparateProcess
      */
-    public function testLoadJsonFromServer(): void
-    {
-        $_SERVER[CredentialsLoader::ENV_VAR] = __DIR__ . '/fixtures7/server.json';
-
-        $json = CredentialsLoader::fromEnv();
-
-        $this->assertArrayHasKey('type', $json);
-        $this->assertEquals('server', $json['type']);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
     public function testLoadJsonFromEnv(): void
     {
         $_ENV[CredentialsLoader::ENV_VAR] = __DIR__ . '/fixtures7/env.json';
@@ -199,7 +186,7 @@ class CredentialsLoaderTest extends TestCase
      */
     public function testLoadJsonFromGetEnvBackwardsCompatibility(): void
     {
-        $_SERVER[CredentialsLoader::ENV_VAR] = __DIR__ . '/fixtures7/server.json';
+        $_ENV[CredentialsLoader::ENV_VAR] = __DIR__ . '/fixtures7/env.json';
         putenv(CredentialsLoader::ENV_VAR . '=' . __DIR__ . '/fixtures7/getenv.json');
 
         $json = CredentialsLoader::fromEnv();

--- a/tests/fixtures7/server.json
+++ b/tests/fixtures7/server.json
@@ -1,1 +1,0 @@
-{"type": "server"}


### PR DESCRIPTION
follow up to https://github.com/googleapis/google-auth-library-php/pull/612

Remove use of `$_SERVER` as it isn't really necessary to support it.

A bit picky of me, but I'd like to keep things as simple as possible.

cc @jannes-io 