### PR TITLE
fix: undefined index error in cache trait

### DIFF
--- a/src/CacheTrait.php
+++ b/src/CacheTrait.php
@@ -95,7 +95,7 @@ trait CacheTrait
             return null;
         }
 
-        $key = $this->cacheConfig['prefix'] . $key;
+        $key = ($this->cacheConfig['prefix'] ?? '') . $key;
 
         // ensure we do not have illegal characters
         $key = preg_replace('|[^a-zA-Z0-9_\.!]|', '', $key);

--- a/tests/Credentials/ImpersonatedServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ImpersonatedServiceAccountCredentialsTest.php
@@ -98,6 +98,19 @@ class ImpersonatedServiceAccountCredentialsTest extends TestCase
         $this->assertEquals('1234567890987654321', $creds->getClientName());
     }
 
+    public function testGetCacheKey()
+    {
+        $creds = new ImpersonatedServiceAccountCredentials(self::SCOPE, [
+            'service_account_impersonation_url' => 'foo',
+            'source_credentials' => [
+                'type' => 'service_account',
+                'client_email' => '123',
+                'private_key' => 'abc'
+            ]
+        ]);
+        $this->assertEquals('foo123.scope1scope2', $creds->getCacheKey());
+    }
+
     public function testMissingImpersonationUriThrowsException()
     {
         $this->expectException(LogicException::class);


### PR DESCRIPTION
fixes https://github.com/googleapis/google-auth-library-php/issues/614

This issue was introduced when `ImpersonatedServiceAccountCredentials` was added - a warning is thrown when calling `getCacheKey` because the underlying `CacheTrait` expects a `cacheConfig` array with key `prefix`. This PR makes that prefix optional, and defaults it to an empty string.