### PR TITLE
chore: drop php 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     test:
         strategy:
             matrix:
-                php: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
+                php: [ "8.1", "8.2", "8.3", "8.4" ]
                 os: [ ubuntu-latest ]
                 include:
                   - os: windows-latest
@@ -40,7 +40,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                php-version: "8.0"
+                php-version: "8.1"
             - name: Install Dependencies
               uses: nick-invision/retry@v3
               with:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "docs": "https://cloud.google.com/php/docs/reference/auth/latest"
   },
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "firebase/php-jwt": "^6.0",
     "guzzlehttp/guzzle": "^7.4.5",
     "guzzlehttp/psr7": "^2.4.5",


### PR DESCRIPTION
We are now 20 months past the EOL of PHP 8.0, and support should be dropped

This is also outside our "[Foundational PHP Support](https://github.com/google/oss-policies-info/blob/main/foundational-php-support-matrix.md)" 

See https://github.com/googleapis/gax-php/pull/619
See https://github.com/googleapis/google-cloud-php/pull/8449