### PR TITLE
feat: Add the rpcName to the logged event

### DIFF
--- a/src/Logging/LoggingTrait.php
+++ b/src/Logging/LoggingTrait.php
@@ -36,6 +36,7 @@ trait LoggingTrait
             'severity' => strtoupper(LogLevel::DEBUG),
             'processId' => $event->processId ?? null,
             'requestId' => $event->requestId ?? null,
+            'rpcName' => $event->rpcName ?? null,
         ];
 
         $debugEvent = array_filter($debugEvent, fn ($value) => !is_null($value));

--- a/tests/Logging/LoggingTraitTest.php
+++ b/tests/Logging/LoggingTraitTest.php
@@ -86,6 +86,18 @@ class LoggingTraitTest extends BaseTest
         $this->assertEquals($event->headers, $parsedDebugEvent['jsonPayload']['response.headers']);
     }
 
+    public function testRpcNameShouldBeIncluded()
+    {
+        $event = $this->getNewLogEvent();
+        $event->headers = ['Thisis' => 'a header'];
+        $this->loggerContainer->logRequest($event);
+
+        $buffer = $this->getActualOutput();
+
+        $parsedDebugEvent = json_decode($buffer, true);
+        $this->assertEquals($event->rpcName, $parsedDebugEvent['rpcName']);
+    }
+
     private function getNewLogEvent(): RpcLogEvent
     {
         $event = new RpcLogEvent();


### PR DESCRIPTION
This adds the `rpcName` to the log when using gRPC.

reference: #628 