### PR TITLE
feat: implement regional access boundaries

### DIFF
--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -153,6 +153,7 @@ class ApplicationDefaultCredentials
      * @param string|null $universeDomain Specifies a universe domain to use for the
      *   calling client library.
      * @param null|false|LoggerInterface $logger A PSR3 compliant LoggerInterface.
+     * @param bool $enableRegionalAccessBoundary Lookup and include the regional access boundary header.
      *
      * @return FetchAuthTokenInterface
      * @throws DomainException if no implementation can be obtained.
@@ -166,6 +167,7 @@ class ApplicationDefaultCredentials
         $defaultScope = null,
         ?string $universeDomain = null,
         null|false|LoggerInterface $logger = null,
+        bool $enableRegionalAccessBoundary = false
     ) {
         $creds = null;
         $jsonKey = CredentialsLoader::fromEnv()
@@ -196,12 +198,18 @@ class ApplicationDefaultCredentials
             $creds = CredentialsLoader::makeCredentials(
                 $scope,
                 $jsonKey,
-                $defaultScope
+                $defaultScope,
+                $enableRegionalAccessBoundary
             );
         } elseif (AppIdentityCredentials::onAppEngine() && !GCECredentials::onAppEngineFlexible()) {
             $creds = new AppIdentityCredentials($anyScope);
         } elseif (self::onGce($httpHandler, $cacheConfig, $cache)) {
-            $creds = new GCECredentials(null, $anyScope, null, $quotaProject, null, $universeDomain);
+            $creds = new GCECredentials(
+                scope: $anyScope,
+                quotaProject: $quotaProject,
+                universeDomain: $universeDomain,
+                enableRegionalAccessBoundary: $enableRegionalAccessBoundary,
+            );
             $creds->setIsOnGce(true); // save the credentials a trip to the metadata server
         }
 
@@ -286,7 +294,7 @@ class ApplicationDefaultCredentials
         $targetAudience,
         ?callable $httpHandler = null,
         ?array $cacheConfig = null,
-        ?CacheItemPoolInterface $cache = null
+        ?CacheItemPoolInterface $cache = null,
     ) {
         $creds = null;
         $jsonKey = CredentialsLoader::fromEnv()
@@ -308,12 +316,20 @@ class ApplicationDefaultCredentials
 
             $creds = match ($jsonKey['type']) {
                 'authorized_user' => new UserRefreshCredentials(null, $jsonKey, $targetAudience),
-                'impersonated_service_account' => new ImpersonatedServiceAccountCredentials(null, $jsonKey, $targetAudience),
-                'service_account' => new ServiceAccountCredentials(null, $jsonKey, null, $targetAudience),
+                'impersonated_service_account' => new ImpersonatedServiceAccountCredentials(
+                    scope: null,
+                    jsonKey: $jsonKey,
+                    targetAudience: $targetAudience,
+                ),
+                'service_account' => new ServiceAccountCredentials(
+                    scope: null,
+                    jsonKey: $jsonKey,
+                    targetAudience: $targetAudience,
+                ),
                 default => throw new InvalidArgumentException('invalid value in the type field')
             };
         } elseif (self::onGce($httpHandler, $cacheConfig, $cache)) {
-            $creds = new GCECredentials(null, null, $targetAudience);
+            $creds = new GCECredentials(targetAudience: $targetAudience);
             $creds->setIsOnGce(true); // save the credentials a trip to the metadata server
         }
 

--- a/src/Cache/SysVCacheItemPool.php
+++ b/src/Cache/SysVCacheItemPool.php
@@ -36,7 +36,7 @@ class SysVCacheItemPool implements CacheItemPoolInterface
 
     const DEFAULT_SEM_PROJ = 'B';
 
-    const DEFAULT_MEMSIZE = 10000;
+    const DEFAULT_MEMSIZE = 100000;
 
     const DEFAULT_PERM = 0600;
 

--- a/src/CacheTrait.php
+++ b/src/CacheTrait.php
@@ -66,9 +66,10 @@ trait CacheTrait
      *
      * @param mixed $k
      * @param mixed $v
+     * @param int|null $lifetime
      * @return mixed
      */
-    private function setCachedValue($k, $v)
+    private function setCachedValue($k, $v, ?int $lifetime = null)
     {
         if (is_null($this->cache)) {
             return null;
@@ -81,7 +82,7 @@ trait CacheTrait
 
         $cacheItem = $this->cache->getItem($key);
         $cacheItem->set($v);
-        $cacheItem->expiresAfter($this->cacheConfig['lifetime']);
+        $cacheItem->expiresAfter($lifetime ?? $this->cacheConfig['lifetime']);
         return $this->cache->save($cacheItem);
     }
 

--- a/src/Credentials/ExternalAccountAuthorizedUserCredentials.php
+++ b/src/Credentials/ExternalAccountAuthorizedUserCredentials.php
@@ -22,6 +22,7 @@ use Google\Auth\CredentialsLoader;
 use Google\Auth\GetQuotaProjectInterface;
 use Google\Auth\GetUniverseDomainInterface;
 use Google\Auth\OAuth2;
+use Google\Auth\UpdateMetadataTrait;
 use InvalidArgumentException;
 
 /**
@@ -32,6 +33,13 @@ use InvalidArgumentException;
  */
 class ExternalAccountAuthorizedUserCredentials extends CredentialsLoader implements GetQuotaProjectInterface
 {
+    use RegionalAccessBoundaryTrait {
+        buildRegionalAccessBoundaryLookupUrl as traitBuildRegionalAccessBoundaryLookupUrl;
+    }
+    use UpdateMetadataTrait {
+        updateMetadata as traitUpdateMetadata;
+    }
+
     /**
      * Used in observability metric headers
      *
@@ -124,6 +132,33 @@ class ExternalAccountAuthorizedUserCredentials extends CredentialsLoader impleme
     }
 
     /**
+     * Updates metadata with the authorization token.
+     *
+     * @param array<mixed> $metadata metadata hashmap
+     * @param string $authUri optional auth uri
+     * @param callable|null $httpHandler callback which delivers psr7 request
+     * @return array<mixed> updated metadata hashmap
+     */
+    public function updateMetadata(
+        $metadata,
+        $authUri = null,
+        ?callable $httpHandler = null
+    ) {
+        $metadata = $this->traitUpdateMetadata($metadata, $authUri, $httpHandler);
+
+        if ($this->enableRegionalAccessBoundary) {
+            $metadata = $this->updateRegionalAccessBoundaryMetadata(
+                $metadata,
+                $this->buildRegionalAccessBoundaryLookupUrl(),
+                $this->getUniverseDomain(),
+                $httpHandler,
+            );
+        }
+
+        return $metadata;
+    }
+
+    /**
      * Return the Cache Key for the credentials.
      * The format for the Cache key is
      * Hash(ClientId.Scope.RefreshToken)
@@ -180,5 +215,33 @@ class ExternalAccountAuthorizedUserCredentials extends CredentialsLoader impleme
     protected function getCredType(): string
     {
         return self::CRED_TYPE;
+    }
+
+    /**
+     * Builds and returns the URL for the RAB lookup API.
+     */
+    private function buildRegionalAccessBoundaryLookupUrl(): string
+    {
+        // Try to parse as a workload identity pool.
+        // Audience format: //iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID
+        $regex = '/projects\/([^\/]+)\/locations\/global\/workloadIdentityPools\/([^\/]+)/';
+        if (preg_match($regex, $this->auth->getAudience(), $matches)) {
+            [$_, $projectNumber, $poolId] = $matches;
+
+            return $this->traitBuildRegionalAccessBoundaryLookupUrl(
+                poolId: $poolId,
+                projectNumber: $projectNumber,
+            );
+        }
+
+        // If that fails, try to parse as a workforce pool.
+        // Audience format: //iam.googleapis.com/locations/global/workforcePools/POOL_ID/providers/PROVIDER_ID
+        if (preg_match('/locations\/[^\/]+\/workforcePools\/([^\/]+)/', $this->auth->getAudience(), $matches)) {
+            return $this->traitBuildRegionalAccessBoundaryLookupUrl(
+                poolId: $matches[1],
+            );
+        }
+
+        throw new LogicException('Invalid audience format');
     }
 }

--- a/src/Credentials/ExternalAccountAuthorizedUserCredentials.php
+++ b/src/Credentials/ExternalAccountAuthorizedUserCredentials.php
@@ -24,6 +24,7 @@ use Google\Auth\GetUniverseDomainInterface;
 use Google\Auth\OAuth2;
 use Google\Auth\UpdateMetadataTrait;
 use InvalidArgumentException;
+use LogicException;
 
 /**
  * Authenticates requests using External Account Authorized User credentials.

--- a/src/Credentials/ExternalAccountCredentials.php
+++ b/src/Credentials/ExternalAccountCredentials.php
@@ -34,6 +34,7 @@ use Google\Auth\UpdateMetadataInterface;
 use Google\Auth\UpdateMetadataTrait;
 use GuzzleHttp\Psr7\Request;
 use InvalidArgumentException;
+use LogicException;
 
 /**
  * **IMPORTANT**:
@@ -51,7 +52,12 @@ class ExternalAccountCredentials implements
     GetUniverseDomainInterface,
     ProjectIdProviderInterface
 {
-    use UpdateMetadataTrait;
+    use UpdateMetadataTrait {
+        updateMetadata as traitUpdateMetadata;
+    }
+    use RegionalAccessBoundaryTrait {
+        buildRegionalAccessBoundaryLookupUrl as traitBuildRegionalAccessBoundaryLookupUrl;
+    }
 
     private const EXTERNAL_ACCOUNT_TYPE = 'external_account';
     private const CLOUD_RESOURCE_MANAGER_URL = 'https://cloudresourcemanager.UNIVERSE_DOMAIN/v1/projects/%s';
@@ -69,10 +75,12 @@ class ExternalAccountCredentials implements
      * @param string|string[] $scope   The scope of the access request, expressed either as an array
      *                                 or as a space-delimited string.
      * @param array<mixed>    $jsonKey JSON credentials as an associative array.
+     * @param bool $enableRegionalAccessBoundary Lookup and include the regional access boundary header.
      */
     public function __construct(
         $scope,
-        array $jsonKey
+        array $jsonKey,
+        bool $enableRegionalAccessBoundary = false
     ) {
         if (!array_key_exists('type', $jsonKey)) {
             throw new InvalidArgumentException('json key is missing the type field');
@@ -114,6 +122,7 @@ class ExternalAccountCredentials implements
         $this->quotaProject = $jsonKey['quota_project_id'] ?? null;
         $this->workforcePoolUserProject = $jsonKey['workforce_pool_user_project'] ?? null;
         $this->universeDomain = $jsonKey['universe_domain'] ?? GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN;
+        $this->enableRegionalAccessBoundary = $enableRegionalAccessBoundary;
 
         $this->auth = new OAuth2([
             'tokenCredentialUri' => $jsonKey['token_url'],
@@ -200,11 +209,8 @@ class ExternalAccountCredentials implements
             }
 
             if ($serviceAccountImpersonationUrl = $jsonKey['service_account_impersonation_url'] ?? null) {
-                // Parse email from URL. The formal looks as follows:
-                // https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/name@project-id.iam.gserviceaccount.com:generateAccessToken
-                $regex = '/serviceAccounts\/(?<email>[^:]+):generateAccessToken$/';
-                if (preg_match($regex, $serviceAccountImpersonationUrl, $matches)) {
-                    $env['GOOGLE_EXTERNAL_ACCOUNT_IMPERSONATED_EMAIL'] = $matches['email'];
+                if ($email = self::getServiceAccountImpersonationEmail($serviceAccountImpersonationUrl)) {
+                    $env['GOOGLE_EXTERNAL_ACCOUNT_IMPERSONATED_EMAIL'] = $email;
                 }
             }
 
@@ -218,6 +224,18 @@ class ExternalAccountCredentials implements
         }
 
         throw new InvalidArgumentException('Unable to determine credential source from json key.');
+    }
+
+    private static function getServiceAccountImpersonationEmail(string $serviceAccountImpersonationUrl): string|null
+    {
+        // Parse email from URL. The formal looks as follows:
+        // https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/name@project-id.iam.gserviceaccount.com:generateAccessToken
+        $regex = '/serviceAccounts\/(?<email>[^:]+):generateAccessToken$/';
+        if (preg_match($regex, $serviceAccountImpersonationUrl, $matches)) {
+            return $matches['email'];
+        }
+
+        return null;
     }
 
     /**
@@ -288,6 +306,37 @@ class ExternalAccountCredentials implements
         }
 
         return $stsToken;
+    }
+
+    /**
+     * Updates metadata with the authorization token.
+     *
+     * @param array<mixed> $metadata metadata hashmap
+     * @param string $authUri optional auth uri
+     * @param callable|null $httpHandler callback which delivers psr7 request
+     * @return array<mixed> updated metadata hashmap
+     */
+    public function updateMetadata(
+        $metadata,
+        $authUri = null,
+        ?callable $httpHandler = null
+    ) {
+        $metadata = $this->traitUpdateMetadata($metadata, $authUri, $httpHandler);
+
+        if ($this->enableRegionalAccessBoundary) {
+            $clientName = $this->serviceAccountImpersonationUrl
+                ? self::getServiceAccountImpersonationEmail($this->serviceAccountImpersonationUrl)
+                : null;
+
+            $metadata = $this->updateRegionalAccessBoundaryMetadata(
+                $metadata,
+                $this->buildRegionalAccessBoundaryLookupUrl($clientName),
+                $this->getUniverseDomain(),
+                $httpHandler,
+            );
+        }
+
+        return $metadata;
     }
 
     /**
@@ -390,5 +439,37 @@ class ExternalAccountCredentials implements
     {
         $regex = '#//iam\.googleapis\.com/locations/[^/]+/workforcePools/#';
         return preg_match($regex, $this->auth->getAudience()) === 1;
+    }
+
+    /**
+     * Builds and returns the URL for the regional access boundary lookup API.
+     */
+    private function buildRegionalAccessBoundaryLookupUrl(string|null $clientName): string
+    {
+        if (null !== $clientName) {
+            return $this->traitBuildRegionalAccessBoundaryLookupUrl(serviceAccountEmail: $clientName);
+        }
+
+        // Try to parse as a workload identity pool.
+        // Audience format: //iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID
+        $regex = '/projects\/([^\/]+)\/locations\/global\/workloadIdentityPools\/([^\/]+)/';
+        if (preg_match($regex, $this->auth->getAudience(), $matches)) {
+            [$_, $projectNumber, $poolId] = $matches;
+
+            return $this->traitBuildRegionalAccessBoundaryLookupUrl(
+                poolId: $poolId,
+                projectNumber: $projectNumber,
+            );
+        }
+
+        // If that fails, try to parse as a workforce pool.
+        // Audience format: //iam.googleapis.com/locations/global/workforcePools/POOL_ID/providers/PROVIDER_ID
+        if (preg_match('/locations\/[^\/]+\/workforcePools\/([^\/]+)/', $this->auth->getAudience(), $matches)) {
+            return $this->traitBuildRegionalAccessBoundaryLookupUrl(
+                poolId: $matches[1],
+            );
+        }
+
+        throw new LogicException('Invalid audience format');
     }
 }

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -651,14 +651,15 @@ class GCECredentials extends CredentialsLoader implements
         $metadata = parent::updateMetadata($metadata, $authUri, $httpHandler);
 
         if ($this->enableRegionalAccessBoundary) {
-            $metadata = $this->updateRegionalAccessBoundaryMetadata(
-                $metadata,
-                $this->buildRegionalAccessBoundaryLookupUrl(
-                    serviceAccountEmail: $this->getClientName($httpHandler)
-                ),
-                $this->getUniverseDomain($httpHandler),
-                $httpHandler,
-            );
+            $serviceAccountEmail = $this->getClientName($httpHandler);
+            if (false !== strpos($serviceAccountEmail, '@')) {
+                $metadata = $this->updateRegionalAccessBoundaryMetadata(
+                    $metadata,
+                    $this->buildRegionalAccessBoundaryLookupUrl($serviceAccountEmail),
+                    $this->getUniverseDomain($httpHandler),
+                    $httpHandler,
+                );
+            }
         }
 
         return $metadata;

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -66,6 +66,7 @@ class GCECredentials extends CredentialsLoader implements
     GetQuotaProjectInterface
 {
     use IamSignerTrait;
+    use RegionalAccessBoundaryTrait;
 
     // phpcs:disable
     const cacheKey = 'GOOGLE_AUTH_PHP_GCE';
@@ -211,6 +212,7 @@ class GCECredentials extends CredentialsLoader implements
      *   account identity name to use instead of "default".
      * @param string|null $universeDomain [optional] Specify a universe domain to use
      *   instead of fetching one from the metadata server.
+     * @param bool $enableRegionalAccessBoundary Lookup and include the regional access boundary header.
      */
     public function __construct(
         ?Iam $iam = null,
@@ -218,7 +220,8 @@ class GCECredentials extends CredentialsLoader implements
         $targetAudience = null,
         $quotaProject = null,
         $serviceAccountIdentity = null,
-        ?string $universeDomain = null
+        ?string $universeDomain = null,
+        bool $enableRegionalAccessBoundary = false
     ) {
         $this->iam = $iam;
 
@@ -247,6 +250,7 @@ class GCECredentials extends CredentialsLoader implements
         $this->quotaProject = $quotaProject;
         $this->serviceAccountIdentity = $serviceAccountIdentity;
         $this->universeDomain = $universeDomain;
+        $this->enableRegionalAccessBoundary = $enableRegionalAccessBoundary;
     }
 
     /**
@@ -629,6 +633,35 @@ class GCECredentials extends CredentialsLoader implements
         }
 
         return $this->universeDomain;
+    }
+
+    /**
+     * Updates metadata with the authorization token.
+     *
+     * @param array<mixed> $metadata metadata hashmap
+     * @param string $authUri optional auth uri
+     * @param callable|null $httpHandler callback which delivers psr7 request
+     * @return array<mixed> updated metadata hashmap
+     */
+    public function updateMetadata(
+        $metadata,
+        $authUri = null,
+        ?callable $httpHandler = null
+    ) {
+        $metadata = parent::updateMetadata($metadata, $authUri, $httpHandler);
+
+        if ($this->enableRegionalAccessBoundary) {
+            $metadata = $this->updateRegionalAccessBoundaryMetadata(
+                $metadata,
+                $this->buildRegionalAccessBoundaryLookupUrl(
+                    serviceAccountEmail: $this->getClientName($httpHandler)
+                ),
+                $this->getUniverseDomain($httpHandler),
+                $httpHandler,
+            );
+        }
+
+        return $metadata;
     }
 
     /**

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -652,7 +652,7 @@ class GCECredentials extends CredentialsLoader implements
 
         if ($this->enableRegionalAccessBoundary) {
             $serviceAccountEmail = $this->getClientName($httpHandler);
-            if (false !== strpos($serviceAccountEmail, '@')) {
+            if (preg_match('/^[^@]+@[^@]+\.[^@]+$/', $serviceAccountEmail)) {
                 $metadata = $this->updateRegionalAccessBoundaryMetadata(
                     $metadata,
                     $this->buildRegionalAccessBoundaryLookupUrl($serviceAccountEmail),

--- a/src/Credentials/ImpersonatedServiceAccountCredentials.php
+++ b/src/Credentials/ImpersonatedServiceAccountCredentials.php
@@ -26,6 +26,8 @@ use Google\Auth\HttpHandler\HttpClientCache;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Auth\IamSignerTrait;
 use Google\Auth\SignBlobInterface;
+use Google\Auth\UpdateMetadataInterface;
+use Google\Auth\UpdateMetadataTrait;
 use GuzzleHttp\Psr7\Request;
 use InvalidArgumentException;
 use LogicException;
@@ -41,10 +43,13 @@ use LogicException;
  */
 class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
     SignBlobInterface,
-    GetUniverseDomainInterface
+    GetUniverseDomainInterface,
+    UpdateMetadataInterface
 {
     use CacheTrait;
     use IamSignerTrait;
+    use UpdateMetadataTrait;
+    use RegionalAccessBoundaryTrait;
 
     private const CRED_TYPE = 'imp';
     private const IAM_SCOPE = 'https://www.googleapis.com/auth/iam';
@@ -100,6 +105,7 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
         string|array $jsonKey,
         private ?string $targetAudience = null,
         string|array|null $defaultScope = null,
+        bool $enableRegionalAccessBoundary = false
     ) {
         if (is_string($jsonKey)) {
             if (!file_exists($jsonKey)) {
@@ -140,7 +146,10 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
             }
             $jsonKey['source_credentials'] = match ($jsonKey['source_credentials']['type'] ?? null) {
                 // Do not pass $defaultScope to ServiceAccountCredentials
-                'service_account' => new ServiceAccountCredentials($scope, $jsonKey['source_credentials']),
+                'service_account' => new ServiceAccountCredentials(
+                    scope: $scope,
+                    jsonKey: $jsonKey['source_credentials'],
+                ),
                 'authorized_user' => new UserRefreshCredentials($scope, $jsonKey['source_credentials']),
                 'external_account' => new ExternalAccountCredentials($scope, $jsonKey['source_credentials']),
                 default => throw new \InvalidArgumentException('invalid value in the type field'),
@@ -157,6 +166,7 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
         );
 
         $this->sourceCredentials = $jsonKey['source_credentials'];
+        $this->enableRegionalAccessBoundary = $enableRegionalAccessBoundary;
     }
 
     /**
@@ -302,5 +312,32 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
         return $this->sourceCredentials instanceof GetUniverseDomainInterface
             ? $this->sourceCredentials->getUniverseDomain()
             : self::DEFAULT_UNIVERSE_DOMAIN;
+    }
+
+    /**
+     * Updates metadata with the authorization token.
+     *
+     * @param array<mixed> $metadata metadata hashmap
+     * @param string $authUri optional auth uri
+     * @param callable|null $httpHandler callback which delivers psr7 request
+     * @return array<mixed> updated metadata hashmap
+     */
+    public function updateMetadata(
+        $metadata,
+        $authUri = null,
+        ?callable $httpHandler = null
+    ) {
+        $metatadata = parent::updateMetadata($metadata, $authUri, $httpHandler);
+
+        $metatadata = $this->updateRegionalAccessBoundaryMetadata(
+            $metatadata,
+            $this->buildRegionalAccessBoundaryLookupUrl(
+                serviceAccountEmail: $this->impersonatedServiceAccountName
+            ),
+            $this->getUniverseDomain(),
+            $httpHandler,
+        );
+
+        return $metatadata;
     }
 }

--- a/src/Credentials/RegionalAccessBoundaryTrait.php
+++ b/src/Credentials/RegionalAccessBoundaryTrait.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Google\Auth\Credentials;
+
+use Google\Auth\CacheTrait;
+use Google\Auth\HttpHandler\HttpClientCache;
+use Google\Auth\HttpHandler\HttpHandlerFactory;
+use Google\Auth\GetUniverseDomainInterface;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use InvalidArgumentException;
+
+/**
+ * Trait for implementing Regional Access Boundaries (RAB) in Credentials.
+ * @internal
+ */
+trait RegionalAccessBoundaryTrait
+{
+    use CacheTrait;
+
+    private bool $enableRegionalAccessBoundary = false;
+
+    /**
+     * @param array<mixed> $headers
+     * @return null|array{locations: array<string>, encodedLocations: string}
+     */
+    private function getRegionalAccessBoundary(
+        string $universeDomain,
+        callable $httpHandler,
+        string $regionalAccessBoundaryUrl,
+        array $headers,
+    ): array|null {
+        if (!$this->enableRegionalAccessBoundary) {
+            // Only look up the RAB if the credentials have been configured to do so
+            return null;
+        }
+
+        if ($universeDomain !== GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN) {
+            // Universe domain is not default, so RAB is not supported.
+            return null;
+        }
+
+        if (array_key_exists('x-allowed-locations', $headers)) {
+            // If the headers are already set, do not set them
+            return null;
+        }
+
+        // Return cached value if it exists
+        if ($cached = $this->getCachedValue($this->getCacheKey() . ':rab')) {
+            return $cached;
+        }
+        if (!array_key_exists('authorization', $headers)) {
+            // If we don't have an authorization token we can't look up the RAB
+            return null;
+        }
+
+        if ($this->getCachedValue($this->getCacheKey() . ':rab:cooldown')) {
+            // We are in a cooldown period, wait until it's over
+            return null;
+        }
+
+        $regionalAccessBoundary = $this->lookupRegionalAccessBoundary(
+            $httpHandler,
+            $regionalAccessBoundaryUrl,
+            $headers['authorization']
+        );
+
+        if (null === $regionalAccessBoundary) {
+            // Do not save null RAB to cache. Instead, fail open and try again on a subsequent request.
+            return null;
+        }
+
+        // Save to cache
+        $tbLifetime = 6 * 60 * 60; // 6-hour cache TTL
+        $this->setCachedValue($this->getCacheKey() . ':rab', $regionalAccessBoundary, $tbLifetime);
+
+        return $regionalAccessBoundary;
+    }
+
+    /**
+     * @param array<mixed> $headers
+     * @return array<mixed>
+     */
+    private function updateRegionalAccessBoundaryMetadata(
+        array $headers,
+        string $regionalAccessBoundaryUrl,
+        string $universeDomain,
+        ?callable $httpHandler,
+    ): array {
+        $httpHandler = $httpHandler
+            ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());
+
+        $regionalAccessBoundaryInfo = $this->getRegionalAccessBoundary(
+            $universeDomain,
+            $httpHandler,
+            $regionalAccessBoundaryUrl,
+            $headers
+        );
+
+        if ($regionalAccessBoundaryInfo) {
+            $headers['x-allowed-locations'] = $regionalAccessBoundaryInfo['encodedLocations'];
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Return the RAB lookup URL.
+     */
+    private function buildRegionalAccessBoundaryLookupUrl(
+        ?string $serviceAccountEmail = null,
+        ?string $poolId = null,
+        ?string $projectNumber = null,
+    ): string {
+        $baseUrl = 'https://iamcredentials.googleapis.com/v1';
+        if ($serviceAccountEmail) {
+            if (is_null($projectNumber) && is_null($poolId)) {
+                return sprintf(
+                    '%s/projects/-/serviceAccounts/%s/allowedLocations',
+                    $baseUrl,
+                    $serviceAccountEmail
+                );
+            }
+        } elseif ($poolId) {
+            if (is_null($projectNumber)) {
+                // Workforce Identity Pools
+                return sprintf(
+                    '%s/locations/global/workforcePools/%s/allowedLocations',
+                    $baseUrl,
+                    $poolId
+                );
+            }
+            // Workload Identity Pools
+            return sprintf(
+                '%s/projects/%s/locations/global/workloadIdentityPools/%s/allowedLocations',
+                $baseUrl,
+                $projectNumber,
+                $poolId
+            );
+        }
+
+        throw new InvalidArgumentException('Must supply $serviceAccountEmail, $poolId, or both $poolId and $projectId');
+    }
+
+    /**
+     * @param array<string> $authHeader
+     * @return null|array{locations: array<string>, encodedLocations: string}
+     */
+    private function lookupRegionalAccessBoundary(
+        callable $httpHandler,
+        string $regionalAccessBoundaryUrl,
+        array $authHeader
+    ): array|null {
+        $request = new Request('GET', $regionalAccessBoundaryUrl);
+        $request = $request->withHeader('authorization', $authHeader);
+        try {
+            $response = $httpHandler($request);
+        } catch (RequestException $e) {
+            // An HTTP error occurred while requesting the RAB lookup
+            // We swallow all errors here as a failed RAB lookup
+            // should not disrupt client authentication.
+            //@TODO Add debug logging
+            $this->initiateCooldown();
+            return null;
+        }
+
+        $regionalAccessBoundary = json_decode((string) $response->getBody(), true);
+        if (null === $regionalAccessBoundary) {
+            // An error occurred during the JSON parsing of the request body
+            // We swallow all errors here as a failed RAB lookup
+            // should not disrupt client authentication.
+            //@TODO Add debug logging
+            $this->initiateCooldown();
+            return null;
+        }
+
+        if (!array_key_exists('encodedLocations', $regionalAccessBoundary)) {
+            // The JSON response did not contain expected "allowLocations"
+            // We swallow all errors here as a failed RAB lookup
+            // should not disrupt client authentication.
+            //@TODO Add debug logging
+            $this->initiateCooldown();
+            return null;
+        }
+
+        return $regionalAccessBoundary;
+    }
+
+    private function initiateCooldown(): void
+    {
+        $cooldownKey = $this->getCacheKey() . ':rab:cooldown';
+        $attempt = $this->getCachedValue($cooldownKey . ':attempt') ?? 0;
+
+        $cooldownBackoff = 15 * 60; // 15 minutes
+        $cooldownMax = 6 * 60 * 60; // 6 hours
+        $cooldownPeriod = min(++$attempt * $cooldownBackoff, $cooldownMax);
+        $this->setCachedValue(
+            $cooldownKey,
+            true,
+            (int) $cooldownPeriod
+        );
+        $this->setCachedValue(
+            $cooldownKey . ':attempt',
+            $attempt,
+            (int) $cooldownPeriod * 2
+        );
+    }
+}

--- a/src/Credentials/RegionalAccessBoundaryTrait.php
+++ b/src/Credentials/RegionalAccessBoundaryTrait.php
@@ -3,9 +3,9 @@
 namespace Google\Auth\Credentials;
 
 use Google\Auth\CacheTrait;
+use Google\Auth\GetUniverseDomainInterface;
 use Google\Auth\HttpHandler\HttpClientCache;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
-use Google\Auth\GetUniverseDomainInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use InvalidArgumentException;

--- a/src/Credentials/RegionalAccessBoundaryTrait.php
+++ b/src/Credentials/RegionalAccessBoundaryTrait.php
@@ -183,6 +183,7 @@ trait RegionalAccessBoundaryTrait
             return null;
         }
 
+        /** @var array{locations: array<string>, encodedLocations: string} $regionalAccessBoundary */
         return $regionalAccessBoundary;
     }
 

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -20,6 +20,8 @@ namespace Google\Auth\Credentials;
 use Firebase\JWT\JWT;
 use Google\Auth\CredentialsLoader;
 use Google\Auth\GetQuotaProjectInterface;
+use Google\Auth\HttpHandler\HttpClientCache;
+use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Auth\Iam;
 use Google\Auth\OAuth2;
 use Google\Auth\ProjectIdProviderInterface;
@@ -68,6 +70,7 @@ class ServiceAccountCredentials extends CredentialsLoader implements
     ProjectIdProviderInterface
 {
     use ServiceAccountSignerTrait;
+    use RegionalAccessBoundaryTrait;
 
     /**
      * Used in observability metric headers
@@ -132,12 +135,14 @@ class ServiceAccountCredentials extends CredentialsLoader implements
      * @param string $sub an email address account to impersonate, in situations when
      *   the service account has been delegated domain wide access.
      * @param string $targetAudience The audience for the ID token.
+     * @param bool $enableRegionalAccessBoundary Lookup and include the regional access boundary header.
      */
     public function __construct(
         $scope,
         $jsonKey,
         $sub = null,
-        $targetAudience = null
+        $targetAudience = null,
+        bool $enableRegionalAccessBoundary = false
     ) {
         if (is_string($jsonKey)) {
             if (!file_exists($jsonKey)) {
@@ -185,6 +190,7 @@ class ServiceAccountCredentials extends CredentialsLoader implements
 
         $this->projectId = $jsonKey['project_id'] ?? null;
         $this->universeDomain = $jsonKey['universe_domain'] ?? self::DEFAULT_UNIVERSE_DOMAIN;
+        $this->enableRegionalAccessBoundary = $enableRegionalAccessBoundary;
     }
 
     /**
@@ -216,9 +222,11 @@ class ServiceAccountCredentials extends CredentialsLoader implements
      */
     public function fetchAuthToken(?callable $httpHandler = null, array $headers = [])
     {
+        $httpHandler = $httpHandler
+            ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());
+
         if ($this->useSelfSignedJwt()) {
             $jwtCreds = $this->createJwtAccessCredentials();
-
             $accessToken = $jwtCreds->fetchAuthToken($httpHandler);
 
             if ($lastReceivedToken = $jwtCreds->getLastReceivedToken()) {
@@ -319,25 +327,50 @@ class ServiceAccountCredentials extends CredentialsLoader implements
         $authUri = null,
         ?callable $httpHandler = null
     ) {
-        // scope exists. use oauth implementation
-        if (!$this->useSelfSignedJwt()) {
-            return parent::updateMetadata($metadata, $authUri, $httpHandler);
-        }
+        $metadata = $this->useSelfSignedJwt()
+            ? $this->updateMetadataSelfSignedJwt($metadata, $authUri, $httpHandler)
+            : parent::updateMetadata($metadata, $authUri, $httpHandler);
 
+        $metadata = $this->updateRegionalAccessBoundaryMetadata(
+            $metadata,
+            $this->buildRegionalAccessBoundaryLookupUrl(
+                serviceAccountEmail: $this->auth->getIssuer()
+            ),
+            $this->getUniverseDomain(),
+            $httpHandler,
+        );
+
+        return $metadata;
+    }
+
+    /**
+     * Updates metadata with the authorization token for SSJWTs.
+     *
+     * @param array<mixed> $metadata metadata hashmap
+     * @param string $authUri optional auth uri
+     * @param callable|null $httpHandler callback which delivers psr7 request
+     * @return array<mixed> updated metadata hashmap
+     */
+    private function updateMetadataSelfSignedJwt(
+        $metadata,
+        $authUri = null,
+        ?callable $httpHandler = null
+    ) {
         $jwtCreds = $this->createJwtAccessCredentials();
-        if ($this->auth->getScope()) {
+
+        $metadata = $jwtCreds->updateMetadata(
+            $metadata,
             // Prefer user-provided "scope" to "audience"
-            $updatedMetadata = $jwtCreds->updateMetadata($metadata, null, $httpHandler);
-        } else {
-            $updatedMetadata = $jwtCreds->updateMetadata($metadata, $authUri, $httpHandler);
-        }
+            $this->auth->getScope() ? null : $authUri,
+            $httpHandler
+        );
 
         if ($lastReceivedToken = $jwtCreds->getLastReceivedToken()) {
             // Keep self-signed JWTs in memory as the last received token
             $this->lastReceivedJwtAccessToken = $lastReceivedToken;
         }
 
-        return $updatedMetadata;
+        return $metadata;
     }
 
     /**

--- a/src/CredentialsLoader.php
+++ b/src/CredentialsLoader.php
@@ -153,12 +153,14 @@ abstract class CredentialsLoader implements
      * @param string|string[] $scope
      * @param array<mixed> $jsonKey
      * @param string|string[] $defaultScope
+     * @param bool $enableRegionalAccessBoundary Lookup and include the regional access boundary header.
      * @return ServiceAccountCredentials|UserRefreshCredentials|ImpersonatedServiceAccountCredentials|ExternalAccountCredentials|ExternalAccountAuthorizedUserCredentials
      */
     public static function makeCredentials(
         $scope,
         array $jsonKey,
-        $defaultScope = null
+        $defaultScope = null,
+        bool $enableRegionalAccessBoundary = false
     ) {
         if (!array_key_exists('type', $jsonKey)) {
             throw new \InvalidArgumentException('json key is missing the type field');
@@ -166,7 +168,7 @@ abstract class CredentialsLoader implements
 
         if ($jsonKey['type'] == 'service_account') {
             // Do not pass $defaultScope to ServiceAccountCredentials
-            return new ServiceAccountCredentials($scope, $jsonKey);
+            return new ServiceAccountCredentials($scope, $jsonKey, enableRegionalAccessBoundary: $enableRegionalAccessBoundary);
         }
 
         if ($jsonKey['type'] == 'authorized_user') {
@@ -175,12 +177,22 @@ abstract class CredentialsLoader implements
         }
 
         if ($jsonKey['type'] == 'impersonated_service_account') {
-            return new ImpersonatedServiceAccountCredentials($scope, $jsonKey, null, $defaultScope);
+            return new ImpersonatedServiceAccountCredentials(
+                $scope,
+                $jsonKey,
+                defaultScope: $defaultScope,
+                enableRegionalAccessBoundary: $enableRegionalAccessBoundary
+            );
         }
 
         if ($jsonKey['type'] == 'external_account') {
             $anyScope = $scope ?: $defaultScope;
-            return new ExternalAccountCredentials($anyScope, $jsonKey);
+            return new ExternalAccountCredentials($anyScope, $jsonKey, $enableRegionalAccessBoundary);
+        }
+
+        if ($jsonKey['type'] == 'external_account_authorized_user') {
+            $anyScope = $scope ?: $defaultScope;
+            return new ExternalAccountAuthorizedUserCredentials($anyScope, $jsonKey);
         }
 
         if ($jsonKey['type'] == 'external_account_authorized_user') {

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -29,6 +29,11 @@ use Google\Auth\CredentialSource;
 use Google\Auth\FetchAuthTokenCache;
 use Google\Auth\GCECache;
 use Google\Auth\Logging\StdOutLogger;
+use Google\Auth\Middleware\AuthTokenMiddleware;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
@@ -894,6 +899,48 @@ class ApplicationDefaultCredentialsTest extends TestCase
                 new Response(404),
             ]), // $httpHandler
         );
-        $this->assertEquals(CredentialsLoader::DEFAULT_UNIVERSE_DOMAIN, $creds2->getUniverseDomain($httpHandler));
+        $this->assertEquals(
+            CredentialsLoader::DEFAULT_UNIVERSE_DOMAIN,
+            $creds2->getUniverseDomain($httpHandler)
+        );
+    }
+
+    public function testRegionalAccessBoundaryLookupIntegration()
+    {
+        if ('true' !== getenv('RUN_TRUST_BOUNDARY_TESTS')) {
+            $this->markTestSkipped('This test requires RUN_TRUST_BOUNDARY_TESTS=true');
+        }
+
+        $creds = ApplicationDefaultCredentials::getCredentials(
+            'https://www.googleapis.com/auth/cloud-platform',
+            enableRegionalAccessBoundary: true,
+        );
+
+        $mock = new MockHandler([
+            new Response(200, [], '{"status":"it worked!"}') // response from KMS
+        ]);
+
+        $container = [];
+        $history = Middleware::history($container);
+
+        $middleware = new AuthTokenMiddleware($creds);
+        $stack = HandlerStack::create($mock);
+        $stack->push($middleware);
+        $stack->push($history);
+
+        $client = new Client([
+            'handler' => $stack,
+            'auth' => 'google_auth'
+        ]);
+
+        $res = $client->get('https://fake.url/');
+        $this->assertEquals('{"status":"it worked!"}', (string) $res->getBody());
+
+        $this->assertCount(1, $container);
+        $this->assertArrayHasKey('request', $container[0]);
+
+        $request = $container[0]['request'];
+        $this->assertTrue($request->hasHeader('x-allowed-locations'));
+        $this->assertEquals('0x80000000000', $request->getHeaderLine('x-allowed-locations'));
     }
 }

--- a/tests/Cache/RaceConditionTest.php
+++ b/tests/Cache/RaceConditionTest.php
@@ -46,13 +46,24 @@ class RaceConditionTest extends TestCase
             $this->markTestSkipped('pcntl_fork is not available');
         }
         for ($i = 0; $i < 50; $i++) {
+            // SysV Cache warmup to prevent segment creation race
+            if ($cacheClass === SysVCacheItemPool::class) {
+                $warmupPool = $this->createCacheItemPool($cacheClass, $i);
+                $warmupItem = $warmupPool->getItem('warmup');
+                $warmupItem->set('ok');
+                $warmupPool->save($warmupItem);
+                unset($warmupPool);
+            }
+
             $pids = [];
             for ($j = 0; $j < 4; $j++) {
                 $pid = pcntl_fork();
                 if ($pid == -1) {
                     $this->fail('Could not fork');
                 }
-                $pool = $this->createCacheItemPool($cacheClass);
+
+                // Always create a new pool instance inside the loop (matches original)
+                $pool = $this->createCacheItemPool($cacheClass, $i);
                 $item = $pool->getItem('foo');
                 $item->set('bar');
                 $this->assertTrue($pool->save($item));
@@ -60,13 +71,26 @@ class RaceConditionTest extends TestCase
                 if ($pid) {
                     // parent
                     $pids[] = $pid;
+                    if ($cacheClass === SysVCacheItemPool::class) {
+                        // For SysV, we must destroy the parent's pool object immediately
+                        // so it is not inherited by the next child process.
+                        unset($pool);
+                    }
                 } else {
                     // child
                     exit(0);
                 }
             }
 
-            // parent
+            // parent final save (matching original test logic)
+            // Note: for SysV, $pool was unset inside the loop, so we must recreate it.
+            // For FileSystem/Memory, $pool is still the one from the last iteration ($j=3).
+            if ($cacheClass === SysVCacheItemPool::class) {
+                $pool = $this->createCacheItemPool($cacheClass, $i);
+                // We need to re-get the item for this new pool
+                $item = $pool->getItem('foo');
+                $item->set('bar');
+            }
             $this->assertTrue($pool->save($item));
 
             foreach ($pids as $pid) {
@@ -79,10 +103,11 @@ class RaceConditionTest extends TestCase
             $this->assertEquals('bar', $cachedItem->get());
 
             $pool->clear();
+            unset($pool);
         }
     }
 
-    public function createCacheItemPool(string $cacheClass): CacheItemPoolInterface
+    public function createCacheItemPool(string $cacheClass, int $iteration = 0): CacheItemPoolInterface
     {
         switch ($cacheClass) {
             case FileSystemCacheItemPool::class:
@@ -91,7 +116,10 @@ class RaceConditionTest extends TestCase
             case MemoryCacheItemPool::class:
                 return new MemoryCacheItemPool();
             case SysVCacheItemPool::class:
-                return new SysVCacheItemPool();
+                return new SysVCacheItemPool([
+                    'proj' => chr(65 + ($iteration % 26)),
+                    'semProj' => chr(97 + ($iteration % 26))
+                ]);
         }
 
         throw new \Exception('Unrecognized cache class: ' . $cacheClass);

--- a/tests/Credentials/ExternalAccountCredentialsTest.php
+++ b/tests/Credentials/ExternalAccountCredentialsTest.php
@@ -686,7 +686,7 @@ class ExternalAccountCredentialsTest extends TestCase
             if ($count === 2) {
                 $this->assertStringContainsString('test@example', $request->getUri()->getPath());
             }
-            return match($count++) {
+            return match ($count++) {
                 0 => new Response(200, [], '{"access_token": "source-token", "expires_in": 3600}'),
                 1 => new Response(200, [], '{"accessToken": "access-token", "expireTime": 1}'),
                 2 => new Response(200, [], '{"locations": [], "encodedLocations": "foo"}'),

--- a/tests/Credentials/ExternalAccountCredentialsTest.php
+++ b/tests/Credentials/ExternalAccountCredentialsTest.php
@@ -24,6 +24,7 @@ use Google\Auth\CredentialSource\UrlSource;
 use Google\Auth\FetchAuthTokenCache;
 use Google\Auth\GetUniverseDomainInterface;
 use Google\Auth\OAuth2;
+use GuzzleHttp\Psr7\Response;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -646,5 +647,72 @@ class ExternalAccountCredentialsTest extends TestCase
             'test-audience,test-token-type,' . $fileContents . PHP_EOL,
             file_get_contents($tmpFile)
         );
+    }
+
+    public function testUpdateMetadataWithRegionalAccessBoundary()
+    {
+        $httpHandler = getHandler([
+            new Response(200, [], '{"access_token": "source-token", "expires_in": 3600}'),
+            new Response(200, [], '{"locations": [], "encodedLocations": "foo"}'),
+        ]);
+        $dir = sys_get_temp_dir();
+        $tokenFile = tempnam($dir, 'token');
+
+        $jsonKey = [
+            'type' => 'external_account',
+            'private_key' => file_get_contents(__DIR__ . '/../fixtures/fixtures1/private.pem'),
+            'client_email' => 'test@example.com',
+            'audience' => '//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROJECT_ID',
+            'subject_token_type' => 'urn:ietf:params:oauth:token-type:jwt',
+            'token_url' => 'https://sts.googleapis.com/v1/token',
+            'credential_source' => ['file' => $tokenFile]
+        ];
+        $serviceAccountCreds = new ExternalAccountCredentials(
+            'a-scope',
+            $jsonKey,
+            enableRegionalAccessBoundary: true
+        );
+
+        $metadata = $serviceAccountCreds->updateMetadata([], null, $httpHandler);
+
+        $this->assertArrayHasKey('x-allowed-locations', $metadata);
+        $this->assertEquals('foo', $metadata['x-allowed-locations']);
+    }
+
+    public function testRegionalAccessBoundaryWithImpersonationUsesServiceAccountEmail()
+    {
+        $count = 0;
+        $httpHandler = function ($request) use (&$count) {
+            if ($count === 2) {
+                $this->assertStringContainsString('test@example', $request->getUri()->getPath());
+            }
+            return match($count++) {
+                0 => new Response(200, [], '{"access_token": "source-token", "expires_in": 3600}'),
+                1 => new Response(200, [], '{"accessToken": "access-token", "expireTime": 1}'),
+                2 => new Response(200, [], '{"locations": [], "encodedLocations": "foo"}'),
+            };
+        };
+        $dir = sys_get_temp_dir();
+        $tokenFile = tempnam($dir, 'token');
+
+        $jsonKey = [
+            'type' => 'external_account',
+            'client_email' => 'test@example.com',
+            'audience' => '//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROJECT_ID',
+            'subject_token_type' => 'urn:ietf:params:oauth:token-type:jwt',
+            'token_url' => 'https://sts.googleapis.com/v1/token',
+            'credential_source' => ['file' => $tokenFile],
+            'service_account_impersonation_url' => 'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/test@example.com:generateAccessToken',
+        ];
+        $serviceAccountCreds = new ExternalAccountCredentials(
+            'a-scope',
+            $jsonKey,
+            enableRegionalAccessBoundary: true
+        );
+
+        $metadata = $serviceAccountCreds->updateMetadata([], null, $httpHandler);
+
+        $this->assertArrayHasKey('x-allowed-locations', $metadata);
+        $this->assertEquals('foo', $metadata['x-allowed-locations']);
     }
 }

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -724,7 +724,7 @@ class GCECredentialsTest extends BaseTest
             return match (++$timesCalled) {
                 1 => new Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
                 2 => new Response(200, [], '{"access_token": "abc", "expires_in": 57}'),
-                3 => new Response(200, [], '{}'),
+                3 => new Response(200, [], '1234567890-compute@developer.gserviceaccount.com'),
                 4 => new Response(200, [], '{"locations": [], "encodedLocations": "foo"}'),
             };
         };
@@ -747,13 +747,35 @@ class GCECredentialsTest extends BaseTest
             return match (++$timesCalled) {
                 1 => new Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
                 2 => new Response(200, [], '{"access_token": "abc", "expires_in": 57}'),
-                3 => new Response(200, [], '{}'),
+                3 => new Response(200, [], '1234567890-compute@developer.gserviceaccount.com'),
             };
         };
 
         $gceCreds = new GCECredentials(
             enableRegionalAccessBoundary: true,
             universeDomain: 'foo.com'
+        );
+
+        $metadata = $gceCreds->updateMetadata([], null, $httpHandler);
+
+        $this->assertArrayNotHasKey('x-allowed-locations', $metadata);
+    }
+
+    public function testUpdateMetadataWithInvalidEmailBypassesRegionalAccessBoundary()
+    {
+        $timesCalled = 0;
+        $httpHandler = function () use (&$timesCalled) {
+            return match (++$timesCalled) {
+                1 => new Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+                2 => new Response(200, [], '{"access_token": "abc", "expires_in": 57}'),
+                3 => new Response(200, [], 'not-an-email'),
+                4 => new Response(200, [], '{"locations": [], "encodedLocations": "foo"}'),
+            };
+        };
+
+        $gceCreds = new GCECredentials(
+            enableRegionalAccessBoundary: true,
+            universeDomain: GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
         );
 
         $metadata = $gceCreds->updateMetadata([], null, $httpHandler);

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -20,6 +20,7 @@ namespace Google\Auth\Tests\Credentials;
 use COM;
 use Exception;
 use Google\Auth\Credentials\GCECredentials;
+use Google\Auth\GetUniverseDomainInterface;
 use Google\Auth\HttpHandler\HttpClientCache;
 use Google\Auth\Tests\BaseTest;
 use GuzzleHttp\Exception\ClientException;
@@ -204,6 +205,9 @@ class GCECredentialsTest extends BaseTest
         $this->assertFalse(GCECredentials::onAppEngineFlexible());
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testOnAppEngineFlexIsTrueWhenGaeInstanceHasAefPrefix()
     {
         putenv('GAE_INSTANCE=aef-default-20180313t154438');
@@ -299,6 +303,7 @@ class GCECredentialsTest extends BaseTest
 
     /**
      * @dataProvider scopes
+     * @runInSeparateProcess
      */
     public function testFetchAuthTokenCustomScope($scope, $expected)
     {
@@ -386,6 +391,9 @@ class GCECredentialsTest extends BaseTest
         $this->assertEquals('', $creds->getClientName($httpHandler));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testSignBlob()
     {
         $expectedEmail = 'test@test.com';
@@ -417,6 +425,9 @@ class GCECredentialsTest extends BaseTest
         $signature = $creds->signBlob($stringToSign);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testSignBlobWithLastReceivedAccessToken()
     {
         $expectedEmail = 'test@test.com';
@@ -458,6 +469,9 @@ class GCECredentialsTest extends BaseTest
         $signature = $creds->signBlob($stringToSign);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testSignBlobWithUniverseDomain()
     {
         $token = [
@@ -496,6 +510,9 @@ class GCECredentialsTest extends BaseTest
         $this->assertEquals('abc123', $signature);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testGetProjectId()
     {
         $expected = 'foobar';
@@ -517,6 +534,9 @@ class GCECredentialsTest extends BaseTest
         $this->assertEquals($expected, $creds->getProjectId());
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testGetProjectIdShouldBeEmptyIfNotOnGCE()
     {
         // simulate retry attempts by returning multiple 500s
@@ -695,5 +715,49 @@ class GCECredentialsTest extends BaseTest
         $expected = 'example-universe.com';
         $creds = new GCECredentials(null, null, null, null, null, $expected);
         $this->assertEquals($expected, $creds->getUniverseDomain());
+    }
+
+    public function testUpdateMetadataWithRegionalAccessBoundary()
+    {
+        $timesCalled = 0;
+        $httpHandler = function () use (&$timesCalled) {
+            return match (++$timesCalled) {
+                1 => new Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+                2 => new Response(200, [], '{"access_token": "abc", "expires_in": 57}'),
+                3 => new Response(200, [], '{}'),
+                4 => new Response(200, [], '{"locations": [], "encodedLocations": "foo"}'),
+            };
+        };
+
+        $gceCreds = new GCECredentials(
+            enableRegionalAccessBoundary: true,
+            universeDomain: GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
+        );
+
+        $metadata = $gceCreds->updateMetadata([], null, $httpHandler);
+
+        $this->assertArrayHasKey('x-allowed-locations', $metadata);
+        $this->assertEquals('foo', $metadata['x-allowed-locations']);
+    }
+
+    public function testUpdateMetadataWithRegionalAccessBoundarySuppressedWithUniverseDomain()
+    {
+        $timesCalled = 0;
+        $httpHandler = function () use (&$timesCalled) {
+            return match (++$timesCalled) {
+                1 => new Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+                2 => new Response(200, [], '{"access_token": "abc", "expires_in": 57}'),
+                3 => new Response(200, [], '{}'),
+            };
+        };
+
+        $gceCreds = new GCECredentials(
+            enableRegionalAccessBoundary: true,
+            universeDomain: 'foo.com'
+        );
+
+        $metadata = $gceCreds->updateMetadata([], null, $httpHandler);
+
+        $this->assertArrayNotHasKey('x-allowed-locations', $metadata);
     }
 }

--- a/tests/Credentials/ImpersonatedServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ImpersonatedServiceAccountCredentialsTest.php
@@ -557,4 +557,58 @@ class ImpersonatedServiceAccountCredentialsTest extends TestCase
             [[], '', $defaultScope, 'expectedScope' => $defaultScope],
         ];
     }
+
+    public function testUpdateMetadataWithRegionalAccessBoundary()
+    {
+        $httpHandler = getHandler([
+            new Response(200, [], '{"access_token": "source-token", "expires_in": 3600}'),
+            new Response(200, [], '{"accessToken": "impersonated-token", "expireTime": "2026-01-01"}'),
+            new Response(200, [], '{"locations": [], "encodedLocations": "foo"}'),
+        ]);
+
+        $jsonKey = [
+            'service_account_impersonation_url' => 'https://iamcredentials.googleapis.com/v1',
+            'source_credentials' => [
+                'type' => 'service_account',
+                'private_key' => file_get_contents(__DIR__ . '/../fixtures/fixtures1/private.pem'),
+                'client_email' => 'test@example.com',
+            ],
+        ];
+        $impersonatedCreds = new ImpersonatedServiceAccountCredentials(
+            'a-scope',
+            $jsonKey,
+            enableRegionalAccessBoundary: true
+        );
+
+        $metadata = $impersonatedCreds->updateMetadata([], null, $httpHandler);
+
+        $this->assertArrayHasKey('x-allowed-locations', $metadata);
+        $this->assertEquals('foo', $metadata['x-allowed-locations']);
+    }
+
+    public function testUpdateMetadataWithRegionalAccessBoundarySuppressedWithUniverseDomain()
+    {
+        $httpHandler = getHandler([
+            new Response(200, [], '{"accessToken": "impersonated-token", "expireTime": "2026-01-01"}'),
+        ]);
+
+        $jsonKey = [
+            'service_account_impersonation_url' => 'https://iamcredentials.googleapis.com/v1',
+            'source_credentials' => [
+                'type' => 'service_account',
+                'private_key' => file_get_contents(__DIR__ . '/../fixtures/fixtures1/private.pem'),
+                'client_email' => 'test@example.com',
+                'universe_domain' => 'foo.com'
+            ],
+        ];
+        $impersonatedCreds = new ImpersonatedServiceAccountCredentials(
+            'a-scope',
+            $jsonKey,
+            enableRegionalAccessBoundary: true
+        );
+
+        $metadata = $impersonatedCreds->updateMetadata([], null, $httpHandler);
+
+        $this->assertArrayNotHasKey('x-allowed-locations', $metadata);
+    }
 }

--- a/tests/Credentials/RegionalAccessBoundaryTraitTest.php
+++ b/tests/Credentials/RegionalAccessBoundaryTraitTest.php
@@ -3,9 +3,9 @@
 namespace Google\Auth\Tests;
 
 use Google\Auth\Cache\MemoryCacheItemPool;
+use Google\Auth\Credentials\RegionalAccessBoundaryTrait;
 use Google\Auth\GetUniverseDomainInterface;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
-use Google\Auth\Credentials\RegionalAccessBoundaryTrait;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;

--- a/tests/Credentials/RegionalAccessBoundaryTraitTest.php
+++ b/tests/Credentials/RegionalAccessBoundaryTraitTest.php
@@ -1,0 +1,401 @@
+<?php
+
+namespace Google\Auth\Tests;
+
+use Google\Auth\Cache\MemoryCacheItemPool;
+use Google\Auth\GetUniverseDomainInterface;
+use Google\Auth\HttpHandler\HttpHandlerFactory;
+use Google\Auth\Credentials\RegionalAccessBoundaryTrait;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+class RegionalAccessBoundaryTraitTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private RegionalAccessBoundaryTraitImpl $impl;
+
+    public function setUp(): void
+    {
+        $this->impl = new RegionalAccessBoundaryTraitImpl();
+    }
+
+    public function testBuildRegionalAccessBoundaryLookupUrl()
+    {
+        $url = $this->impl->buildRegionalAccessBoundaryLookupUrl(serviceAccountEmail: 'test@example.com');
+        $this->assertEquals(
+            'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/test@example.com/allowedLocations',
+            $url
+        );
+    }
+
+    public function testLookupRegionalAccessBoundary()
+    {
+        $responseBody =
+            '{"locations": ["us-central1", "us-east1", "europe-west1", "asia-east1"], "enodedLocations": ""0xA30"}';
+        $handler = getHandler([
+            new Response(200, [], $responseBody),
+        ]);
+        $result = $this->impl->lookupRegionalAccessBoundary($handler, 'default', ['Bearer xyz']);
+        $this->assertEquals(json_decode($responseBody, true), $result);
+    }
+
+    public function testLookupRegionalAccessBoundary404()
+    {
+        $handler = getHandler([
+            new Response(404)
+        ]);
+        $result = $this->impl->lookupRegionalAccessBoundary($handler, 'default', ['Bearer xyz']);
+        $this->assertNull($result);
+    }
+
+    public function testSkipLookupOutsideDefaultUniverseDomain()
+    {
+        // First call, should fetch and cache
+        $result1 = $this->impl->getRegionalAccessBoundary(
+            'universe.domain',
+            fn () => throw new \Exception('Should not be called'),
+            'default',
+            ['authorization' => ['xyz']]
+        );
+
+        $this->assertNull($result1);
+    }
+
+    public function testSkipLookupIfXAllowedLocationsAreAlreadySet()
+    {
+        // First call, should fetch and cache
+        $result1 = $this->impl->getRegionalAccessBoundary(
+            'universe.domain',
+            fn () => throw new \Exception('Should not be called'),
+            'default',
+            ['authorization' => ['xyz'], ['x-allowed-locations' => 'abc']]
+        );
+
+        $this->assertNull($result1);
+    }
+
+    public function testLookupIsFailOpen()
+    {
+        $mock = new MockHandler([
+            new RequestException('Error Communicating with Server', new Request('GET', 'test'))
+        ]);
+        $handler = HttpHandlerFactory::build(new Client(['handler' => $mock]));
+
+        $this->assertNull($mock->getLastRequest());
+
+        // First call, should fetch and cache
+        $result1 = $this->impl->getRegionalAccessBoundary(
+            GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
+            $handler,
+            'default',
+            ['authorization' => ['xyz']]
+        );
+
+        // Ensure the request was made and the error was swallowed
+        $this->assertNotNull($mock->getLastRequest());
+        $this->assertNull($result1);
+    }
+
+    public function testRefreshRegionalAccessBoundaryWithCache()
+    {
+        $cache = new MemoryCacheItemPool();
+        $this->impl->setCache($cache);
+        $responseBody =
+            '{"locations": ["us-central1", "us-east1", "europe-west1", "asia-east1"], "encodedLocations": "0xA30"}';
+        $handler = getHandler([
+            new Response(200, [], $responseBody),
+        ]);
+
+        // First call, should fetch and cache
+        $result1 = $this->impl->getRegionalAccessBoundary(
+            GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
+            $handler,
+            'default',
+            ['authorization' => ['xyz']]
+        );
+        $this->assertEquals(json_decode($responseBody, true), $result1);
+
+        // Second call, should return from cache
+        $handler = getHandler([
+            new Response(500), // This should not be called
+        ]);
+        $result2 = $this->impl->getRegionalAccessBoundary(
+            GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
+            $handler,
+            'default',
+            []
+        );
+        $this->assertEquals(json_decode($responseBody, true), $result2);
+    }
+
+    public function testRefreshRegionalAccessBoundaryWithCacheAfterExpiry()
+    {
+        $cache = new MemoryCacheItemPool();
+        $this->impl->setCache($cache);
+        $cachedResponseBody =
+            '{"locations": ["cached-locations"], "encodedLocations": "0xA30"}';
+
+        $cacheItem = $cache->getItem('testkeyrab');
+        $cacheItem->set(json_decode($cachedResponseBody, true));
+        $cacheItem->expiresAt(\DateTime::createFromFormat('U', time() + 1)); // in the future
+        $cache->save($cacheItem);
+
+        // First call, should fetch from cache
+        $result1 = $this->impl->getRegionalAccessBoundary(
+            GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
+            fn () => throw new \Exception('Should not be called'),
+            'default',
+            ['authorization' => ['xyz']]
+        );
+        $this->assertEquals(json_decode($cachedResponseBody, true), $result1);
+
+        // Set cache to expired
+        $cacheItem->expiresAt(\DateTime::createFromFormat('U', time() - 1)); // in the future
+        $cache->save($cacheItem);
+
+        // Second call, should return from HTTP call
+        $responseBody =
+            '{"locations": ["noncached-locations"], "encodedLocations": "0xA30"}';
+        $handler = getHandler([
+            new Response(200, [], $responseBody),
+        ]);
+
+        $result2 = $this->impl->getRegionalAccessBoundary(
+            GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
+            $handler,
+            'default',
+            ['authorization' => ['xyz']]
+        );
+        $this->assertEquals(json_decode($responseBody, true), $result2);
+    }
+
+    public function testCacheLifetime()
+    {
+        $cacheItem = $this->prophesize(CacheItemInterface::class);
+        $cacheItem->isHit()->shouldBeCalledOnce()->willReturn(false);
+        $cacheItem->set(Argument::any())->shouldBeCalledOnce()->willReturn($cacheItem->reveal());
+        $cacheItem->expiresAfter(6 * 60 * 60)->shouldBeCalledOnce()->willReturn($cacheItem->reveal());
+
+        $cache = $this->prophesize(CacheItemPoolInterface::class);
+        $cache->getItem('testkeyrab')
+            ->shouldBeCalledTimes(2)
+            ->willReturn($cacheItem->reveal());
+        $cache->save($cacheItem->reveal())->shouldBeCalledOnce()->willReturn(true);
+
+        $cooldownCacheItem = $this->prophesize(CacheItemInterface::class);
+        $cooldownCacheItem->isHit()->shouldBeCalledOnce()->willReturn(false);
+        $cache->getItem('testkeyrabcooldown')
+            ->shouldBeCalledOnce()
+            ->willReturn($cooldownCacheItem->reveal());
+
+        $this->impl->setCache($cache->reveal());
+
+        $responseBody =
+            '{"locations": ["us-central1", "us-east1", "europe-west1", "asia-east1"], "encodedLocations": "0xA30"}';
+        $handler = getHandler([
+            new Response(200, [], $responseBody)
+        ]);
+        // First call, should fetch and cache
+        $result1 = $this->impl->getRegionalAccessBoundary(
+            GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
+            $handler,
+            'default',
+            ['authorization' => ['xyz']]
+        );
+
+        $this->assertNotNull($result1);
+        $this->assertEquals(json_decode($responseBody, true), $result1);
+    }
+
+    public function testSkipLookupDuringCooldown()
+    {
+        $cache = $this->prophesize(CacheItemPoolInterface::class);
+
+        $cacheItem = $this->prophesize(CacheItemInterface::class);
+        $cacheItem->isHit()->shouldBeCalledOnce()->willReturn(false);
+        $cache->getItem('testkeyrab')
+            ->shouldBeCalledOnce()
+            ->willReturn($cacheItem->reveal());
+
+        $cooldownCacheItem = $this->prophesize(CacheItemInterface::class);
+        $cooldownCacheItem->isHit()->shouldBeCalledOnce()->willReturn(true);
+        $cooldownCacheItem->get()->shouldBeCalledOnce()->willReturn(true);
+
+        $cache->getItem('testkeyrabcooldown')
+            ->shouldBeCalledOnce()
+            ->willReturn($cooldownCacheItem->reveal());
+
+        $this->impl->setCache($cache->reveal());
+
+        // First call, should fetch and cache
+        $result1 = $this->impl->getRegionalAccessBoundary(
+            GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
+            fn () => throw new \Exception('Should not be called'),
+            'default',
+            ['authorization' => ['xyz']]
+        );
+
+        $this->assertNull($result1);
+    }
+
+    public function testSkipCooldownAfterExpiry()
+    {
+        $cache = new MemoryCacheItemPool();
+
+        $cacheItem = $cache->getItem('testkeyrabcooldown');
+        $cacheItem->set(true);
+        $cacheItem->expiresAt(\DateTime::createFromFormat('U', time() - 1)); // in the past
+        $cache->save($cacheItem);
+
+        $this->impl->setCache($cache);
+
+        $result = $this->impl->getRegionalAccessBoundary(
+            GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
+            getHandler([new Response(200, [], '{"encodedLocations": "0xA30"}')]),
+            'default',
+            ['authorization' => ['xyz']]
+        );
+
+        $this->assertEquals(['encodedLocations' => '0xA30'], $result);
+    }
+
+    public function provideCooldown()
+    {
+        $fifteenMinutes = 15 * 60; // cooldown increment
+        $sixHours = 6 * 60 * 60; // max cooldown
+        return [
+            [0, $fifteenMinutes],
+            [1, $fifteenMinutes * 2],
+            [1000, $sixHours],
+        ];
+    }
+
+    /**
+     * @dataProvider provideCooldown
+     */
+    public function testInitiateCooldown(int $attempt, int $expectedExpiry)
+    {
+        $cache = $this->prophesize(CacheItemPoolInterface::class);
+
+        $cacheItem = $this->prophesize(CacheItemInterface::class);
+        $cacheItem->isHit()->shouldBeCalledOnce()->willReturn(false);
+        $cache->getItem('testkeyrab')
+            ->shouldBeCalledOnce()
+            ->willReturn($cacheItem->reveal());
+
+        $cooldownCacheItem = $this->prophesize(CacheItemInterface::class);
+        $cooldownCacheItem->isHit()->shouldBeCalledOnce()->willReturn(false);
+        $cooldownCacheItem->set(true)->shouldBeCalledOnce()->willReturn($cooldownCacheItem->reveal());
+        $cooldownCacheItem->expiresAfter($expectedExpiry)->shouldBeCalledOnce()->willReturn($cooldownCacheItem->reveal());
+        $cache->getItem('testkeyrabcooldown')
+            ->shouldBeCalledTimes(2)
+            ->willReturn($cooldownCacheItem->reveal());
+        $cache->save($cooldownCacheItem->reveal())->shouldBeCalledOnce()->willReturn(true);
+
+        $cooldownCacheItemAttempt = $this->prophesize(CacheItemInterface::class);
+        if (0 === $attempt) {
+            $cooldownCacheItemAttempt->isHit()->shouldBeCalledOnce()->willReturn(false);
+        } else {
+            $cooldownCacheItemAttempt->isHit()->shouldBeCalledOnce()->willReturn(true);
+            $cooldownCacheItemAttempt->get()->shouldBeCalledOnce()->willReturn($attempt);
+        }
+        $cooldownCacheItemAttempt->set($attempt + 1)->shouldBeCalledOnce()->willReturn($cooldownCacheItemAttempt->reveal());
+        $cooldownCacheItemAttempt->expiresAfter($expectedExpiry * 2)->shouldBeCalledOnce()->willReturn($cooldownCacheItemAttempt->reveal());
+        $cache->getItem('testkeyrabcooldownattempt')
+            ->shouldBeCalledTimes(2)
+            ->willReturn($cooldownCacheItemAttempt->reveal());
+        $cache->save($cooldownCacheItemAttempt->reveal())->shouldBeCalledOnce()->willReturn(true);
+
+        $this->impl->setCache($cache->reveal());
+
+        $mock = new MockHandler([
+            new RequestException('Error Communicating with Server (1)', new Request('GET', 'test')),
+        ]);
+        $handler = HttpHandlerFactory::build(new Client(['handler' => $mock]));
+
+        // First call, should fetch and cache
+        $result1 = $this->impl->getRegionalAccessBoundary(
+            GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
+            $handler,
+            'default',
+            ['authorization' => ['xyz']]
+        );
+
+        $this->assertNull($result1);
+    }
+
+    public function provideMalformedResponseFromAllowLocationsLookup()
+    {
+        return [
+            [200, '{"locations": ["us-west1"]}'], // missing allowLocations
+            [200, '{"locations": ["us-west1"]'],  // invalid JSON
+            [401, ''],                            // 4xx error
+            [500, ''],                            // 5xx error
+        ];
+    }
+
+    /**
+     * @dataProvider provideMalformedResponseFromAllowLocationsLookup
+     */
+    public function testMalformedResponseFromAllowLocationsLookup(int $statusCode, string $responseBody)
+    {
+        $this->impl->setCache(new MemoryCacheItemPool());
+        $handler = getHandler([
+            new Response($statusCode, [], $responseBody),
+        ]);
+        $result = $this->impl->getRegionalAccessBoundary(
+            GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
+            $handler,
+            'default',
+            ['authorization' => ['xyz']]
+        );
+
+        $this->assertNull($result);
+        $this->assertTrue($this->impl->cooldownIsActive());
+    }
+}
+
+class RegionalAccessBoundaryTraitImpl
+{
+    use RegionalAccessBoundaryTrait {
+        buildRegionalAccessBoundaryLookupUrl as public;
+        lookupRegionalAccessBoundary as public;
+        getRegionalAccessBoundary as public;
+    }
+
+    private $cache;
+    private $cacheConfig;
+
+    public function __construct(array $config = [])
+    {
+        $this->cacheConfig = [
+            'prefix' => '',
+            'lifetime' => 1000,
+        ];
+        $this->enableRegionalAccessBoundary = true;
+    }
+
+    public function getCacheKey()
+    {
+        return 'test-key';
+    }
+
+    public function setCache($cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function cooldownIsActive(): bool
+    {
+        return (bool) $this->getCachedValue($this->getCacheKey() . ':rab:cooldown');
+    }
+}

--- a/tests/Credentials/ServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountCredentialsTest.php
@@ -424,4 +424,47 @@ class ServiceAccountCredentialsTest extends TestCase
         $sa = new ServiceAccountCredentials('scope/1', $keyFile);
         $this->assertEquals('test_quota_project', $sa->getQuotaProject());
     }
+
+    public function testUpdateMetadataWithRegionalAccessBoundary()
+    {
+        $httpHandler = getHandler([
+            new Response(200, [], '{"access_token": "source-token", "expires_in": 3600}'),
+            new Response(200, [], '{"locations": [], "encodedLocations": "foo"}'),
+        ]);
+
+        $jsonKey = [
+            'type' => 'service_account',
+            'private_key' => file_get_contents(__DIR__ . '/../fixtures/fixtures1/private.pem'),
+            'client_email' => 'test@example.com',
+        ];
+        $serviceAccountCreds = new ServiceAccountCredentials(
+            'a-scope',
+            $jsonKey,
+            enableRegionalAccessBoundary: true
+        );
+
+        $metadata = $serviceAccountCreds->updateMetadata([], null, $httpHandler);
+
+        $this->assertArrayHasKey('x-allowed-locations', $metadata);
+        $this->assertEquals('foo', $metadata['x-allowed-locations']);
+    }
+
+    public function testUpdateMetadataWithRegionalAccessBoundarySuppressedWithUniverseDomain()
+    {
+        $jsonKey = [
+            'type' => 'service_account',
+            'private_key' => file_get_contents(__DIR__ . '/../fixtures/fixtures1/private.pem'),
+            'client_email' => 'test@example.com',
+            'universe_domain' => 'foo.com',
+        ];
+        $serviceAccountCreds = new ServiceAccountCredentials(
+            'a-scope',
+            $jsonKey,
+            enableRegionalAccessBoundary: true
+        );
+
+        $metadata = $serviceAccountCreds->updateMetadata([]);
+
+        $this->assertArrayNotHasKey('x-allowed-locations', $metadata);
+    }
 }

--- a/tests/Credentials/ServiceAccountJwtAccessCredentialsTest.php
+++ b/tests/Credentials/ServiceAccountJwtAccessCredentialsTest.php
@@ -552,4 +552,28 @@ class ServiceAccountJwtAccessCredentialsTest extends TestCase
         $this->assertArrayHasKey('scope', $json);
         $this->assertEquals($json['scope'], implode(' ', $scope));
     }
+
+    public function testUpdateMetadataWithRegionalAccessBoundary()
+    {
+        $httpHandler = getHandler([
+            new Response(200, [], '{"locations": [], "encodedLocations": "foo"}'),
+        ]);
+
+        $jsonKey = [
+            'type' => 'service_account',
+            'private_key' => file_get_contents(__DIR__ . '/../fixtures/fixtures1/private.pem'),
+            'client_email' => 'test@example.com',
+        ];
+        $serviceAccountCreds = new ServiceAccountCredentials(
+            'a-scope',
+            $jsonKey,
+            enableRegionalAccessBoundary: true
+        );
+        $serviceAccountCreds->useJwtAccessWithScope();
+
+        $metadata = $serviceAccountCreds->updateMetadata([], null, $httpHandler);
+
+        $this->assertArrayHasKey('x-allowed-locations', $metadata);
+        $this->assertEquals('foo', $metadata['x-allowed-locations']);
+    }
 }

--- a/tests/FetchAuthTokenCacheTest.php
+++ b/tests/FetchAuthTokenCacheTest.php
@@ -282,7 +282,7 @@ class FetchAuthTokenCacheTest extends BaseTest
         $this->assertEquals($metadata, $metadata2);
 
         // Ensure token for different URI is NOT cached
-        $metadata3 = $cachedFetcher->updateMetadata([], 'http://test-auth-uri-2');
+        $metadata3 = $cachedFetcher->updateMetadata([], 'http://test-auth-uri-2', getHandler([new Response(200)]));
         $this->assertNotEquals($metadata, $metadata3);
     }
 


### PR DESCRIPTION
b/480120031

## Credential Support

 - [x] Impersonated Service Account Credentials 
 - [x] Service Account Credentials and Service Account JWT Credentials
 - [x] Metadata Credentials
 - [x] External Account Authorized User Credentials

## Implementation

 - [x] Universe Check
 - [x] Skip lookup if in cooldown
 - [x] Cooldown state trigger
 - [x] 6-Hour TTL
 - [x] Lookup request should be fail open

_Features which require work in GAX_ 
 - [x] Skip lookup if endpoint is regional
 - [ ] "stale RAB" error handling

_Optional features (to be evaluated)_
 - [ ] Async lookup Trigger
 - [ ] Async Retry Mechanism
 - [x] ~~Manual override seeding~~ (will not implement)

## Testing

 - [x] Universe Check
 - [x] Skip lookup if in cooldown
 - [x] Cooldown state trigger
 - [x] 6-Hour TTL
 - [x] Lookup request should be fail open
 - [x] E2E: Impersonated Service Account Credentials (Staging)
 - [x] E2E: Service Account Credentials and Service Account JWT Credentials (Staging)
 - [x] E2E: Metadata Credentials (Blocked)
 - [x] E2E: External Account Authorized User Credentials