### PR TITLE
fix: ImpersonatedCredentials getLastReceivedToken returns correct token

### DIFF
--- a/src/Credentials/ImpersonatedServiceAccountCredentials.php
+++ b/src/Credentials/ImpersonatedServiceAccountCredentials.php
@@ -72,6 +72,8 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
 
     private int $lifetime;
 
+    protected array|null $lastReceivedToken = null;
+
     /**
      * Instantiate an instance of ImpersonatedServiceAccountCredentials from a credentials file that
      * has be created with the --impersonate-service-account flag.
@@ -252,7 +254,7 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
         $response = $httpHandler($request);
         $body = json_decode((string) $response->getBody(), true);
 
-        return match ($this->isIdTokenRequest()) {
+        return $this->lastReceivedToken = match ($this->isIdTokenRequest()) {
             true => ['id_token' => $body['token']],
             false => [
                 'access_token' => $body['accessToken'],
@@ -279,7 +281,7 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
      */
     public function getLastReceivedToken()
     {
-        return $this->sourceCredentials->getLastReceivedToken();
+        return $this->lastReceivedToken;
     }
 
     protected function getCredType(): string

--- a/src/Credentials/ImpersonatedServiceAccountCredentials.php
+++ b/src/Credentials/ImpersonatedServiceAccountCredentials.php
@@ -72,6 +72,9 @@ class ImpersonatedServiceAccountCredentials extends CredentialsLoader implements
 
     private int $lifetime;
 
+    /**
+     * @var array<mixed>|null
+     */
     protected array|null $lastReceivedToken = null;
 
     /**

--- a/tests/Credentials/ImpersonatedServiceAccountCredentialsTest.php
+++ b/tests/Credentials/ImpersonatedServiceAccountCredentialsTest.php
@@ -186,6 +186,7 @@ class ImpersonatedServiceAccountCredentialsTest extends TestCase
         $token = $creds->fetchAuthToken($httpHandler);
         $this->assertEquals('test-impersonated-access-token', $token['access_token']);
         $this->assertEquals(2, $requestCount);
+        $this->assertEquals($token, $creds->getLastReceivedToken());
     }
 
     /**
@@ -225,6 +226,7 @@ class ImpersonatedServiceAccountCredentialsTest extends TestCase
         $token = $creds->fetchAuthToken($httpHandler);
         $this->assertEquals('test-impersonated-access-token', $token['access_token']);
         $this->assertEquals(3, $requestCount);
+        $this->assertEquals($token, $creds->getLastReceivedToken());
     }
 
     /**
@@ -266,6 +268,7 @@ class ImpersonatedServiceAccountCredentialsTest extends TestCase
         $token = $creds->fetchAuthToken($httpHandler);
         $this->assertEquals('test-impersonated-id-token', $token['id_token']);
         $this->assertEquals(2, $requestCount);
+        $this->assertEquals($token, $creds->getLastReceivedToken());
     }
 
     public function provideAuthTokenJson()
@@ -307,6 +310,7 @@ class ImpersonatedServiceAccountCredentialsTest extends TestCase
         $creds = new ImpersonatedServiceAccountCredentials(null, $json, self::TARGET_AUDIENCE);
         $token = $creds->fetchAuthToken($httpHandler);
         $this->assertEquals('test-impersonated-id-token', $token['id_token']);
+        $this->assertEquals($token, $creds->getLastReceivedToken());
     }
 
     /**
@@ -378,6 +382,7 @@ class ImpersonatedServiceAccountCredentialsTest extends TestCase
         $token = $creds->fetchAuthToken($httpHandler);
         $this->assertEquals('test-impersonated-id-token', $token['id_token']);
         $this->assertEquals(3, $requestCount);
+        $this->assertEquals($token, $creds->getLastReceivedToken());
     }
 
     /**
@@ -416,6 +421,7 @@ class ImpersonatedServiceAccountCredentialsTest extends TestCase
 
         $token = $creds->fetchAuthToken($httpHandler);
         $this->assertEquals('test-impersonated-id-token', $token['id_token']);
+        $this->assertEquals($token, $creds->getLastReceivedToken());
     }
 
     public function provideUniverseDomain()
@@ -455,6 +461,7 @@ class ImpersonatedServiceAccountCredentialsTest extends TestCase
 
         $token = $creds->fetchAuthToken($httpHandler);
         $this->assertEquals('test-impersonated-access-token', $token['access_token']);
+        $this->assertEquals($token, $creds->getLastReceivedToken());
     }
 
     public function testIdTokenWithAuthTokenMiddleware()


### PR DESCRIPTION
fixes https://github.com/googleapis/google-auth-library-php/issues/622