### PR TITLE
feat(aws): support container credentials in AwsNativeSource

### DIFF
--- a/src/CredentialSource/AwsNativeSource.php
+++ b/src/CredentialSource/AwsNativeSource.php
@@ -74,9 +74,21 @@ class AwsNativeSource implements ExternalAccountCredentialSourceInterface
             ];
         }
 
-        if (!$signingVars = self::getSigningVarsFromEnv()) {
+        $signingVars = self::getSigningVarsFromEnv();
+        if (!$signingVars) {
+            // Container Credentials (ECS Fargate task role / EKS Pod Identity /
+            // AWS Greengrass etc.) expose credentials via a localhost endpoint
+            // referenced by AWS_CONTAINER_CREDENTIALS_{RELATIVE,FULL}_URI rather
+            // than by the EC2 IMDS-style securityCredentialsUrl. Try that path
+            // before falling back to the configured securityCredentialsUrl.
+            $signingVars = self::getSigningVarsFromContainerCredentials($httpHandler);
+        }
+        if (!$signingVars) {
             if (!$this->securityCredentialsUrl) {
-                throw new \LogicException('Unable to get credentials from ENV, and no security credentials URL provided');
+                throw new \LogicException(
+                    'Unable to get credentials from ENV or container credentials, '
+                    . 'and no security credentials URL provided'
+                );
             }
             $signingVars = self::getSigningVarsFromUrl(
                 $httpHandler,
@@ -326,6 +338,65 @@ class AwsNativeSource implements ExternalAccountCredentialSourceInterface
         }
 
         return null;
+    }
+
+    /**
+     * Retrieves AWS signing credentials from the container credentials
+     * provider, when running on ECS Fargate, EKS Pod Identity, AWS Greengrass,
+     * or any other environment that exposes credentials through the
+     * `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` /
+     * `AWS_CONTAINER_CREDENTIALS_FULL_URI` interface.
+     *
+     * The endpoint returns a JSON body with `AccessKeyId`, `SecretAccessKey`
+     * and `Token` fields, mirroring the format used by the EC2 instance
+     * metadata service but addressed directly without the role-name
+     * suffix used by IMDS.
+     *
+     * @see https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html
+     *
+     * @internal
+     *
+     * @param callable $httpHandler
+     *
+     * @return array{string, string, ?string}|null `null` when neither container
+     *     credentials env var is set, signaling that the caller should fall
+     *     through to the next credentials provider.
+     */
+    public static function getSigningVarsFromContainerCredentials(callable $httpHandler): ?array
+    {
+        $relativeUri = getenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI');
+        $fullUri = getenv('AWS_CONTAINER_CREDENTIALS_FULL_URI');
+        if (empty($relativeUri) && empty($fullUri)) {
+            return null;
+        }
+
+        $url = !empty($relativeUri)
+            ? 'http://169.254.170.2' . $relativeUri
+            : (string) $fullUri;
+
+        $headers = [];
+        if ($authToken = getenv('AWS_CONTAINER_AUTHORIZATION_TOKEN')) {
+            $headers['Authorization'] = $authToken;
+        } elseif ($authTokenFile = getenv('AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE')) {
+            if (is_readable($authTokenFile)) {
+                $headers['Authorization'] = trim((string) file_get_contents($authTokenFile));
+            }
+        }
+
+        $request = new Request('GET', $url, $headers);
+        $response = $httpHandler($request);
+        $awsCreds = json_decode((string) $response->getBody(), true);
+        if (!is_array($awsCreds)
+            || !isset($awsCreds['AccessKeyId'], $awsCreds['SecretAccessKey'])
+        ) {
+            return null;
+        }
+
+        return [
+            $awsCreds['AccessKeyId'],
+            $awsCreds['SecretAccessKey'],
+            $awsCreds['Token'] ?? null,
+        ];
     }
 
     /**

--- a/tests/CredentialSource/AwsNativeSourceTest.php
+++ b/tests/CredentialSource/AwsNativeSourceTest.php
@@ -239,7 +239,7 @@ class AwsNativeSourceTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(
-            'Unable to get credentials from ENV, and no security credentials URL provided'
+            'Unable to get credentials from ENV or container credentials, and no security credentials URL provided'
         );
 
         $aws = new AwsNativeSource(
@@ -256,6 +256,154 @@ class AwsNativeSourceTest extends TestCase
             return $awsTokenResponse->reveal();
         };
         $aws->fetchSubjectToken($httpHandler);
+    }
+
+    /** @runInSeparateProcess */
+    public function testGetSigningVarsFromContainerCredentialsReturnsNullWhenEnvNotSet()
+    {
+        // Neither AWS_CONTAINER_CREDENTIALS_RELATIVE_URI nor _FULL_URI is set.
+        $httpHandler = function (RequestInterface $request): ResponseInterface {
+            throw new \LogicException('HTTP handler should not be invoked when no container credentials env is set.');
+        };
+
+        $this->assertNull(
+            AwsNativeSource::getSigningVarsFromContainerCredentials($httpHandler)
+        );
+    }
+
+    /** @runInSeparateProcess */
+    public function testGetSigningVarsFromContainerCredentialsRelativeUri()
+    {
+        putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/v2/credentials/abcdef');
+
+        $httpHandler = function (RequestInterface $request): ResponseInterface {
+            $this->assertEquals('GET', $request->getMethod());
+            $this->assertEquals(
+                'http://169.254.170.2/v2/credentials/abcdef',
+                (string) $request->getUri()
+            );
+            $this->assertFalse($request->hasHeader('Authorization'));
+
+            $body = $this->prophesize(StreamInterface::class);
+            $body->__toString()->willReturn(json_encode([
+                'AccessKeyId' => 'expected-access-key-id',
+                'SecretAccessKey' => 'expected-secret-access-key',
+                'Token' => 'expected-token',
+            ]));
+            $response = $this->prophesize(ResponseInterface::class);
+            $response->getBody()->willReturn($body->reveal());
+
+            return $response->reveal();
+        };
+
+        $signingVars = AwsNativeSource::getSigningVarsFromContainerCredentials($httpHandler);
+
+        $this->assertEquals('expected-access-key-id', $signingVars[0]);
+        $this->assertEquals('expected-secret-access-key', $signingVars[1]);
+        $this->assertEquals('expected-token', $signingVars[2]);
+    }
+
+    /** @runInSeparateProcess */
+    public function testGetSigningVarsFromContainerCredentialsFullUriWithAuthToken()
+    {
+        $fullUri = 'http://eks-pod-identity.example/credentials';
+        putenv('AWS_CONTAINER_CREDENTIALS_FULL_URI=' . $fullUri);
+        putenv('AWS_CONTAINER_AUTHORIZATION_TOKEN=expected-bearer-token');
+
+        $httpHandler = function (RequestInterface $request) use ($fullUri): ResponseInterface {
+            $this->assertEquals('GET', $request->getMethod());
+            $this->assertEquals($fullUri, (string) $request->getUri());
+            $this->assertEquals('expected-bearer-token', $request->getHeaderLine('Authorization'));
+
+            $body = $this->prophesize(StreamInterface::class);
+            $body->__toString()->willReturn(json_encode([
+                'AccessKeyId' => 'full-access-key-id',
+                'SecretAccessKey' => 'full-secret-access-key',
+                // Token is optional in the response (e.g. long-lived creds).
+            ]));
+            $response = $this->prophesize(ResponseInterface::class);
+            $response->getBody()->willReturn($body->reveal());
+
+            return $response->reveal();
+        };
+
+        $signingVars = AwsNativeSource::getSigningVarsFromContainerCredentials($httpHandler);
+
+        $this->assertEquals('full-access-key-id', $signingVars[0]);
+        $this->assertEquals('full-secret-access-key', $signingVars[1]);
+        $this->assertNull($signingVars[2]);
+    }
+
+    /** @runInSeparateProcess */
+    public function testFetchSubjectTokenFromContainerCredentials()
+    {
+        // Simulate ECS Fargate: AWS_ACCESS_KEY_ID is unset but
+        // AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is provided. fetchSubjectToken
+        // should fall through to the container credentials endpoint instead of
+        // throwing or hitting the (unconfigured) securityCredentialsUrl.
+        putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/v2/credentials/task-role');
+
+        $aws = new AwsNativeSource(
+            $this->audience,
+            $this->regionUrl,
+            $this->regionalCredVerificationUrl,
+        );
+
+        // Mock response from container credentials endpoint
+        $containerBody = $this->prophesize(StreamInterface::class);
+        $containerBody->__toString()->willReturn(json_encode([
+            'AccessKeyId' => 'container-access-key-id',
+            'SecretAccessKey' => 'container-secret-access-key',
+            'Token' => 'container-session-token',
+        ]));
+        $containerResponse = $this->prophesize(ResponseInterface::class);
+        $containerResponse->getBody()->willReturn($containerBody->reveal());
+
+        // Mock response from Region URL
+        $regionBody = $this->prophesize(StreamInterface::class);
+        $regionBody->__toString()->willReturn('us-east-2b');
+        $regionResponse = $this->prophesize(ResponseInterface::class);
+        $regionResponse->getBody()->willReturn($regionBody->reveal());
+
+        $requestCount = 0;
+        $httpHandler = function (RequestInterface $request) use (
+            $containerResponse,
+            $regionResponse,
+            &$requestCount
+        ): ResponseInterface {
+            $requestCount++;
+            switch ($requestCount) {
+                case 1:
+                    $this->assertEquals(
+                        'http://169.254.170.2/v2/credentials/task-role',
+                        (string) $request->getUri()
+                    );
+                    return $containerResponse->reveal();
+                case 2:
+                    return $regionResponse->reveal();
+            }
+            throw new \Exception('Unexpected request');
+        };
+
+        $subjectToken = $aws->fetchSubjectToken($httpHandler);
+        $unserializedToken = json_decode(urldecode($subjectToken), true);
+        $this->assertArrayHasKey('headers', $unserializedToken);
+        $this->assertArrayHasKey('method', $unserializedToken);
+        $this->assertArrayHasKey('url', $unserializedToken);
+
+        // Sanity check: the SigV4 Authorization header must reference the
+        // access key fetched from the container credentials endpoint.
+        $authHeader = '';
+        foreach ($unserializedToken['headers'] as $header) {
+            if ($header['key'] === 'Authorization') {
+                $authHeader = $header['value'];
+                break;
+            }
+        }
+        $this->assertStringContainsString(
+            'Credential=container-access-key-id/',
+            $authHeader
+        );
     }
 
     /**


### PR DESCRIPTION
## Problem

When running on ECS Fargate (task IAM role), EKS Pod Identity, AWS Greengrass, or any other environment that exposes credentials via the [container credentials provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html), the WIF (`external_account` / AWS) credential flow fails:

- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` are **not** in the environment — the credential URI is exposed via `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` / `AWS_CONTAINER_CREDENTIALS_FULL_URI` instead.
- `AwsNativeSource::getSigningVarsFromUrl()` is hard-coded to the EC2 IMDS pattern (`<securityCredentialsUrl>/<role-name>`); the ECS / EKS endpoint returns the credential JSON directly without a role-name suffix, so even pointing `securityCredentialsUrl` at the ECS URL would not work.

The user-visible failure today is:

```
LogicException: Unable to get credentials from ENV, and no security credentials URL provided
  at Google\Auth\CredentialSource\AwsNativeSource::fetchSubjectToken
```

…even though the same task can resolve credentials with `aws-sdk-php`'s `CredentialProvider::defaultProvider()`. This forces downstream applications to add a "bridge" in their bootstrap code that resolves AWS credentials via aws-sdk-php and `putenv`s them so that `AwsNativeSource` can pick them up — clearly something the auth library should be able to do natively.

## Change

Add a third credential resolution step in `AwsNativeSource::fetchSubjectToken()`, slotted between the existing ENV lookup and the existing IMDS-style `securityCredentialsUrl` fallback:

| Order | Source | Status |
|---|---|---|
| 1 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env | existing |
| 2 | **`AWS_CONTAINER_CREDENTIALS_{RELATIVE,FULL}_URI`** | **new** |
| 3 | EC2 IMDS via `securityCredentialsUrl` constructor arg | existing |
| 4 | `LogicException` | existing (message updated) |

The new path:

- Reads `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` and prefixes it with `http://169.254.170.2`, OR uses `AWS_CONTAINER_CREDENTIALS_FULL_URI` directly.
- Honors `AWS_CONTAINER_AUTHORIZATION_TOKEN` (literal) and `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` (file contents) by setting an `Authorization:` header on the GET request — required by EKS Pod Identity and IAM Roles Anywhere container scenarios.
- Parses the JSON response (`AccessKeyId` / `SecretAccessKey` / `Token`) — same schema as the EC2 metadata response — so the rest of the SigV4 pipeline is unchanged.
- Returns `null` when no container credentials env var is set, so the caller falls through to the existing `securityCredentialsUrl` path.

The new method `getSigningVarsFromContainerCredentials()` mirrors the visibility (`public static`, marked `@internal`) of `getSigningVarsFromEnv()` / `getSigningVarsFromUrl()` for consistency and testability.

## Tests

```
$ vendor/bin/phpunit tests/CredentialSource/AwsNativeSourceTest.php
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

..............                                                    14 / 14 (100%)

OK (14 tests, 66 assertions)
```

Four new tests under `tests/CredentialSource/AwsNativeSourceTest.php`:

- `testGetSigningVarsFromContainerCredentialsReturnsNullWhenEnvNotSet` — guarantees the new path is opt-in (HTTP handler must not be invoked when no env var is set).
- `testGetSigningVarsFromContainerCredentialsRelativeUri` — verifies the `http://169.254.170.2` prefix and the absence of an `Authorization:` header for the ECS Fargate task-role case.
- `testGetSigningVarsFromContainerCredentialsFullUriWithAuthToken` — covers EKS Pod Identity (`FULL_URI` + `AWS_CONTAINER_AUTHORIZATION_TOKEN`) and the optional-`Token`-in-response case.
- `testFetchSubjectTokenFromContainerCredentials` — end-to-end: with `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` set and no `securityCredentialsUrl`, `fetchSubjectToken()` produces a SigV4-signed STS GetCallerIdentity request whose `Authorization` header references the access key fetched from the container endpoint.

The existing `testFetchSubjectTokenWithoutSecurityCredentialsUrlOrEnvThrowsException` is updated for the new exception message.

## Backwards compatibility

- No constructor signature change.
- New behavior is **strictly additive**: when the new env vars are absent, behavior is identical to today (env → securityCredentialsUrl → throw).
- The `LogicException` message is updated from "Unable to get credentials from ENV, and no security credentials URL provided" to mention container credentials. This message is not part of the public API; if keeping the legacy wording is preferred I'm happy to drop the rewording in a follow-up commit.

## CLA

Will sign the [individual CLA](http://code.google.com/legal/individual-cla-v1.0.html) when the bot prompts.