### PR TITLE
docs: fix phpdoc codeblocks in credentials classes

### DIFF
--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -40,23 +40,25 @@ use InvalidArgumentException;
  * It can be used to authorize requests using the AuthTokenMiddleware, but will
  * only succeed if being run on GCE:
  *
- *   use Google\Auth\Credentials\GCECredentials;
- *   use Google\Auth\Middleware\AuthTokenMiddleware;
- *   use GuzzleHttp\Client;
- *   use GuzzleHttp\HandlerStack;
+ * ```
+ * use Google\Auth\Credentials\GCECredentials;
+ * use Google\Auth\Middleware\AuthTokenMiddleware;
+ * use GuzzleHttp\Client;
+ * use GuzzleHttp\HandlerStack;
  *
- *   $gce = new GCECredentials();
- *   $middleware = new AuthTokenMiddleware($gce);
- *   $stack = HandlerStack::create();
- *   $stack->push($middleware);
+ * $gce = new GCECredentials();
+ * $middleware = new AuthTokenMiddleware($gce);
+ * $stack = HandlerStack::create();
+ * $stack->push($middleware);
  *
- *   $client = new Client([
- *      'handler' => $stack,
- *      'base_uri' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
- *      'auth' => 'google_auth'
- *   ]);
+ * $client = new Client([
+ *    'handler' => $stack,
+ *    'base_uri' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
+ *    'auth' => 'google_auth'
+ * ]);
  *
- *   $res = $client->get('myproject/taskqueues/myqueue');
+ * $res = $client->get('myproject/taskqueues/myqueue');
+ * ```
  */
 class GCECredentials extends CredentialsLoader implements
     SignBlobInterface,

--- a/src/Credentials/ServiceAccountCredentials.php
+++ b/src/Credentials/ServiceAccountCredentials.php
@@ -39,26 +39,28 @@ use InvalidArgumentException;
  *
  * Use it with AuthTokenMiddleware to authorize http requests:
  *
- *   use Google\Auth\Credentials\ServiceAccountCredentials;
- *   use Google\Auth\Middleware\AuthTokenMiddleware;
- *   use GuzzleHttp\Client;
- *   use GuzzleHttp\HandlerStack;
+ * ```
+ * use Google\Auth\Credentials\ServiceAccountCredentials;
+ * use Google\Auth\Middleware\AuthTokenMiddleware;
+ * use GuzzleHttp\Client;
+ * use GuzzleHttp\HandlerStack;
  *
- *   $sa = new ServiceAccountCredentials(
- *       'https://www.googleapis.com/auth/taskqueue',
- *       '/path/to/your/json/key_file.json'
- *   );
- *   $middleware = new AuthTokenMiddleware($sa);
- *   $stack = HandlerStack::create();
- *   $stack->push($middleware);
+ * $sa = new ServiceAccountCredentials(
+ *     'https://www.googleapis.com/auth/taskqueue',
+ *     '/path/to/your/json/key_file.json'
+ * );
+ * $middleware = new AuthTokenMiddleware($sa);
+ * $stack = HandlerStack::create();
+ * $stack->push($middleware);
  *
- *   $client = new Client([
- *       'handler' => $stack,
- *       'base_uri' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
- *       'auth' => 'google_auth' // authorize all requests
- *   ]);
+ * $client = new Client([
+ *     'handler' => $stack,
+ *     'base_uri' => 'https://www.googleapis.com/taskqueue/v1beta2/projects/',
+ *     'auth' => 'google_auth' // authorize all requests
+ * ]);
  *
- *   $res = $client->get('myproject/taskqueues/myqueue');
+ * $res = $client->get('myproject/taskqueues/myqueue');
+ * ```
  */
 class ServiceAccountCredentials extends CredentialsLoader implements
     GetQuotaProjectInterface,


### PR DESCRIPTION
Fixes broken PHPDoc codeblocks in 
 - https://docs.cloud.google.com/php/docs/reference/auth/latest/Credentials.ServiceAccountCredentials
 - https://docs.cloud.google.com/php/docs/reference/auth/latest/Credentials.GCECredentials

See https://github.com/googleapis/google-cloud-php/issues/9186