### PR TITLE
docs: proper placement of deprecation tag

### DIFF
--- a/src/ApplicationDefaultCredentials.php
+++ b/src/ApplicationDefaultCredentials.php
@@ -76,7 +76,6 @@ class ApplicationDefaultCredentials
     private const SDK_DEBUG_ENV_VAR = 'GOOGLE_SDK_PHP_LOGGING';
 
     /**
-     * @deprecated
      *
      * Obtains an AuthTokenSubscriber that uses the default FetchAuthTokenInterface
      * implementation to use in this environment.
@@ -84,6 +83,7 @@ class ApplicationDefaultCredentials
      * If supplied, $scope is used to in creating the credentials instance if
      * this does not fallback to the compute engine defaults.
      *
+     * @deprecated
      * @param string|string[] $scope the scope of the access request, expressed
      *        either as an Array or as a space-delimited String.
      * @param callable|null $httpHandler callback which delivers psr7 request

--- a/src/Credentials/AppIdentityCredentials.php
+++ b/src/Credentials/AppIdentityCredentials.php
@@ -28,8 +28,6 @@ use Google\Auth\ProjectIdProviderInterface;
 use Google\Auth\SignBlobInterface;
 
 /**
- * @deprecated
- *
  * AppIdentityCredentials supports authorization on Google App Engine.
  *
  * It can be used to authorize requests using the AuthTokenMiddleware or
@@ -55,6 +53,7 @@ use Google\Auth\SignBlobInterface;
  *
  * $res = $client->get('volumes?q=Henry+David+Thoreau&country=US');
  * ```
+ * @deprecated
  */
 class AppIdentityCredentials extends CredentialsLoader implements
     SignBlobInterface,

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -686,12 +686,12 @@ class OAuth2 implements FetchAuthTokenInterface
     }
 
     /**
-     * @deprecated
      *
      * Obtains a key that can used to cache the results of #fetchAuthToken.
      *
      * The key is derived from the scopes.
      *
+     * @deprecated
      * @return ?string a key that may be used to cache the auth token.
      */
     public function getCacheKey()

--- a/src/UpdateMetadataTrait.php
+++ b/src/UpdateMetadataTrait.php
@@ -31,8 +31,8 @@ trait UpdateMetadataTrait
     /**
      * export a callback function which updates runtime metadata.
      *
-     * @return callable updateMetadata function
      * @deprecated
+     * @return callable updateMetadata function
      */
     public function getUpdateMetadataFunc()
     {


### PR DESCRIPTION
`@deprecated` tags MUST go after the phpdoc description, and SHOULD go before everything else

see https://softwareengineering.stackexchange.com/questions/256382/does-phpdocumentor-tags-order-matter

This will ensure the `@deprecated` tag description is parsed as expected in https://github.com/googleapis/google-cloud-php/pull/9245