### PR TITLE
test(auth): verify graceful failure on missing HOME or APPDATA

### DIFF
--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -91,6 +91,37 @@ class ApplicationDefaultCredentialsTest extends TestCase
         ApplicationDefaultCredentials::getCredentials('a scope', $httpHandler);
     }
 
+    /** @runInSeparateProcess */
+    public function testGracefulFailureOnMissingHomeAndAppData()
+    {
+        // Ensure that missing HOME or APPDATA environment variables result in a graceful failure.
+        // A DomainException should be thrown instead of triggering raw PHP warnings or crashing.
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('Your default credentials were not found');
+
+        // Unset both HOME and APPDATA
+        putenv('HOME');
+        putenv('APPDATA');
+
+        // Ensure we don't get credentials from any other env var
+        putenv(CredentialsLoader::ENV_VAR);
+
+        // Mock GCE check to return false via cache hit
+        $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
+        $mockCacheItem->isHit()->willReturn(true);
+        $mockCacheItem->get()->willReturn(false);
+
+        $mockCache = $this->prophesize(CacheItemPoolInterface::class);
+        $mockCache->getItem(GCECache::GCE_CACHE_KEY)->willReturn($mockCacheItem->reveal());
+
+        ApplicationDefaultCredentials::getCredentials(
+            'a scope',
+            null,
+            null,
+            $mockCache->reveal()
+        );
+    }
+
     public function testSuccedsIfNoDefaultFilesButIsOnGCE()
     {
         setHomeEnv(null);


### PR DESCRIPTION
Adds a test to verify that if HOME and APPDATA are unset, and GCE metadata is not available, the resolution fails with a graceful DomainException.

Other languages (such as Node.js and Python) handle missing HOME or APPDATA directories by falling back gracefully or failing with a structured Exception. This test ensures the PHP library maintains parity by asserting an orderly DomainException is thrown instead of emitting PHP warnings or crashing.