### PR TITLE
docs: fix ADC specific-JSON-key example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ If you want to use a specific JSON key instead of using `GOOGLE_APPLICATION_CRED
  do this:
 
 ```php
-use Google\Auth\CredentialsLoader;
+use Google\Auth\Credentials\ServiceAccountCredentials;
+use Google\Auth\Credentials\UserRefreshCredentials;
+use Google\Auth\FetchAuthTokenCache;
 use Google\Auth\Middleware\AuthTokenMiddleware;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
@@ -172,13 +174,13 @@ $jsonKey = ['key' => 'value'];
 $scopes = ['https://www.googleapis.com/auth/drive.readonly'];
 
 // Load credentials from JSON containing service account credentials.
-$creds = new ServiceAccountCredentials($scopes, $jsonKey),
+$creds = new ServiceAccountCredentials($scopes, $jsonKey);
 
 // For other credentials types, create those classes explicitly using the
 // "type" field in the JSON key, for example:
 $creds = match ($jsonKey['type']) {
-    'service_account' => new ServiceAccountCredentials($scope, $jsonKey),
-    'authorized_user' => new UserRefreshCredentials($scope, $jsonKey),
+    'service_account' => new ServiceAccountCredentials($scopes, $jsonKey),
+    'authorized_user' => new UserRefreshCredentials($scopes, $jsonKey),
     default => throw new InvalidArgumentException('This application only supports service account and user account credentials'),
 };
 


### PR DESCRIPTION
The "Call using a specific JSON key" example in the README does not parse and can't be
copy-pasted as-is. This fixes three issues in that snippet:

- A trailing comma (`,`) instead of a semicolon after the first `new ServiceAccountCredentials(...)` assignment — a parse error.
- The `match` arms reference `$scope`, but the variable defined above is `$scopes`.
- Missing `use` imports for `ServiceAccountCredentials`, `UserRefreshCredentials`, and `FetchAuthTokenCache`.

Documentation only — no code or behavior changes. Verified the corrected snippet with `php -l`.