### PR TITLE
feat: support full-format identity tokens on GCE

### DIFF
--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -213,6 +213,10 @@ class GCECredentials extends CredentialsLoader implements
      * @param string|null $universeDomain [optional] Specify a universe domain to use
      *   instead of fetching one from the metadata server.
      * @param bool $enableRegionalAccessBoundary Lookup and include the regional access boundary header.
+     * @param string|null $idTokenFormat [optional] The format of the identity token requested
+     *   from the metadata server when $targetAudience is set. One of "standard" or "full".
+     *   Use "full" to include the full VM instance details in the token payload (for example,
+     *   the authorized party's email). Defaults to the metadata server's default ("standard").
      */
     public function __construct(
         ?Iam $iam = null,
@@ -221,13 +225,20 @@ class GCECredentials extends CredentialsLoader implements
         $quotaProject = null,
         $serviceAccountIdentity = null,
         ?string $universeDomain = null,
-        bool $enableRegionalAccessBoundary = false
+        bool $enableRegionalAccessBoundary = false,
+        ?string $idTokenFormat = null
     ) {
         $this->iam = $iam;
 
         if ($scope && $targetAudience) {
             throw new InvalidArgumentException(
                 'Scope and targetAudience cannot both be supplied'
+            );
+        }
+
+        if ($idTokenFormat !== null && !in_array($idTokenFormat, ['standard', 'full'], true)) {
+            throw new InvalidArgumentException(
+                'Invalid idTokenFormat, must be one of "standard" or "full"'
             );
         }
 
@@ -243,6 +254,9 @@ class GCECredentials extends CredentialsLoader implements
         } elseif ($targetAudience) {
             $tokenUri = self::getIdTokenUri($serviceAccountIdentity);
             $tokenUri = $tokenUri . '?audience=' . $targetAudience;
+            if ($idTokenFormat !== null) {
+                $tokenUri = $tokenUri . '&format=' . $idTokenFormat;
+            }
             $this->targetAudience = $targetAudience;
         }
 

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -305,6 +305,34 @@ class GCECredentialsTest extends BaseTest
         $this->assertEquals(2, $timesCalled);
     }
 
+    public function testFetchAuthTokenAppendsFullFormatToIdTokenRequest()
+    {
+        $expectedToken = ['id_token' => 'idtoken12345'];
+        $timesCalled = 0;
+        $httpHandler = function ($request) use (&$timesCalled, $expectedToken) {
+            $timesCalled++;
+            if ($timesCalled == 1) {
+                return new Psr7\Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']);
+            }
+            $this->assertEquals(
+                'audience=a+target+audience&format=full',
+                $request->getUri()->getQuery()
+            );
+            return new Psr7\Response(200, [], Utils::streamFor($expectedToken['id_token']));
+        };
+        $g = new GCECredentials(null, null, 'a+target+audience', null, null, null, false, 'full');
+        $this->assertEquals($expectedToken, $g->fetchAuthToken($httpHandler));
+        $this->assertEquals(2, $timesCalled);
+    }
+
+    public function testInvalidIdTokenFormatThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid idTokenFormat, must be one of "standard" or "full"');
+
+        new GCECredentials(null, null, 'a+target+audience', null, null, null, false, 'invalid');
+    }
+
     public function testSettingBothScopeAndTargetAudienceThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
 Fixes googleapis/google-cloud-php#9679.

On GCE/Cloud Run, the identity token returned by the metadata server omits the full payload (for example, the authorized party's email) unless `format=full` is requested. The Python auth library already does this; this brings PHP in line.

Adds an optional, backward-compatible `$idTokenFormat` argument to the `GCECredentials` constructor. When a target audience is set, passing `'full'` appends `&format=full` to the metadata identity request:
```php
use Google\Auth\Credentials\GCECredentials;
$creds = new GCECredentials(
     targetAudience: 'https://my-service.run.app',
     idTokenFormat: 'full',
 );
```

The value is validated to `standard` or `full`. Existing callers are unaffected (the default preserves the current request). Scoped to `GCECredentials`; exposing the option through `ApplicationDefaultCredentials::getIdTokenCredentials` is a natural follow-up kept out of this PR to keep it to one subject.

Unit tests cover the appended query string and the validation error.