### PR TITLE
chore: add private static variable to skip GCE residency checks

### DIFF
--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -111,9 +111,9 @@ class GCECredentials extends CredentialsLoader implements
     const FLAVOR_HEADER = 'Metadata-Flavor';
 
     /**
-     * The environment variable that indicates that the check for GCE should be skipped.
+     * Flag used to determine whether to perform the GCE residency check. Used for testing.
      */
-    const NO_GCE_CHECK_ENV_VAR = 'NO_GCE_CHECK';
+    private static bool $checkResidency = true;
 
     /**
      * The Linux file which contains the product name.
@@ -371,10 +371,6 @@ class GCECredentials extends CredentialsLoader implements
      */
     public static function onGce(?callable $httpHandler = null)
     {
-        if (getenv(self::NO_GCE_CHECK_ENV_VAR)) {
-            return false;
-        }
-
         $httpHandler = $httpHandler
             ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());
 
@@ -407,6 +403,10 @@ class GCECredentials extends CredentialsLoader implements
             } catch (RequestException $e) {
             } catch (NetworkExceptionInterface $e) {
             }
+        }
+
+        if (!self::$checkResidency) {
+            return false;
         }
 
         if (PHP_OS === 'Windows' || PHP_OS === 'WINNT') {

--- a/src/Credentials/GCECredentials.php
+++ b/src/Credentials/GCECredentials.php
@@ -111,6 +111,11 @@ class GCECredentials extends CredentialsLoader implements
     const FLAVOR_HEADER = 'Metadata-Flavor';
 
     /**
+     * The environment variable that indicates that the check for GCE should be skipped.
+     */
+    const NO_GCE_CHECK_ENV_VAR = 'NO_GCE_CHECK';
+
+    /**
      * The Linux file which contains the product name.
      */
     private const GKE_PRODUCT_NAME_FILE = '/sys/class/dmi/id/product_name';
@@ -366,6 +371,10 @@ class GCECredentials extends CredentialsLoader implements
      */
     public static function onGce(?callable $httpHandler = null)
     {
+        if (getenv(self::NO_GCE_CHECK_ENV_VAR)) {
+            return false;
+        }
+
         $httpHandler = $httpHandler
             ?: HttpHandlerFactory::build(HttpClientCache::getHttpClient());
 

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -85,7 +85,7 @@ class ApplicationDefaultCredentialsTest extends TestCase
     {
         $this->expectException(DomainException::class);
 
-        skipGceCheck();
+        skipResidencyCheck();
         setHomeEnv(__DIR__ . '/not_exist_fixtures');
         // simulate not being GCE and retry attempts by returning multiple 500s
         $httpHandler = getHandler([
@@ -301,7 +301,7 @@ class ApplicationDefaultCredentialsTest extends TestCase
     {
         $this->expectException(DomainException::class);
 
-        skipGceCheck();
+        skipResidencyCheck();
         setHomeEnv(__DIR__ . '/not_exist_fixtures');
 
         // simulate not being GCE and retry attempts by returning multiple 500s
@@ -485,7 +485,7 @@ class ApplicationDefaultCredentialsTest extends TestCase
         $this->expectException(DomainException::class);
         $this->expectExceptionMessage('Your default credentials were not found');
 
-        skipGceCheck();
+        skipResidencyCheck();
         setHomeEnv(__DIR__ . '/not_exist_fixtures');
 
         // simulate not being GCE and retry attempts by returning multiple 500s

--- a/tests/ApplicationDefaultCredentialsTest.php
+++ b/tests/ApplicationDefaultCredentialsTest.php
@@ -85,6 +85,7 @@ class ApplicationDefaultCredentialsTest extends TestCase
     {
         $this->expectException(DomainException::class);
 
+        skipGceCheck();
         setHomeEnv(__DIR__ . '/not_exist_fixtures');
         // simulate not being GCE and retry attempts by returning multiple 500s
         $httpHandler = getHandler([
@@ -300,6 +301,7 @@ class ApplicationDefaultCredentialsTest extends TestCase
     {
         $this->expectException(DomainException::class);
 
+        skipGceCheck();
         setHomeEnv(__DIR__ . '/not_exist_fixtures');
 
         // simulate not being GCE and retry attempts by returning multiple 500s
@@ -483,6 +485,7 @@ class ApplicationDefaultCredentialsTest extends TestCase
         $this->expectException(DomainException::class);
         $this->expectExceptionMessage('Your default credentials were not found');
 
+        skipGceCheck();
         setHomeEnv(__DIR__ . '/not_exist_fixtures');
 
         // simulate not being GCE and retry attempts by returning multiple 500s

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -44,7 +44,7 @@ class GCECredentialsTest extends BaseTest
 
     protected function tearDown(): void
     {
-        skipGceCheck(false);
+        skipResidencyCheck(false);
         parent::tearDown();
     }
 
@@ -80,18 +80,9 @@ class GCECredentialsTest extends BaseTest
         $this->assertTrue($handerInvoked);
     }
 
-    public function testOnGceIsFalseWhenNoGceCheckEnvVarSet()
-    {
-        skipGceCheck();
-        $httpHandler = getHandler([
-            new Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
-        ]);
-        $this->assertFalse(GCECredentials::onGce($httpHandler));
-    }
-
     public function testOnGCEIsFalseOnClientErrorStatus()
     {
-        skipGceCheck();
+        skipResidencyCheck();
 
         // simulate retry attempts by returning multiple 400s
         $httpHandler = getHandler([
@@ -104,7 +95,7 @@ class GCECredentialsTest extends BaseTest
 
     public function testOnGCEIsFalseOnServerErrorStatus()
     {
-        skipGceCheck();
+        skipResidencyCheck();
 
         // simulate retry attempts by returning multiple 500s
         $httpHandler = getHandler([
@@ -117,7 +108,7 @@ class GCECredentialsTest extends BaseTest
 
     public function testOnGCEIsFalseOnNetworkError()
     {
-        skipGceCheck();
+        skipResidencyCheck();
 
         // simulate retry attempts by returning multiple network errors
         $httpHandler = getHandler([
@@ -256,7 +247,7 @@ class GCECredentialsTest extends BaseTest
 
     public function testFetchAuthTokenShouldBeEmptyIfNotOnGCE()
     {
-        skipGceCheck();
+        skipResidencyCheck();
 
         // simulate retry attempts by returning multiple 500s
         $httpHandler = getHandler([
@@ -415,7 +406,7 @@ class GCECredentialsTest extends BaseTest
 
     public function testGetClientNameShouldBeEmptyIfNotOnGCE()
     {
-        skipGceCheck();
+        skipResidencyCheck();
 
         // simulate retry attempts by returning multiple 500s
         $httpHandler = getHandler([

--- a/tests/Credentials/GCECredentialsTest.php
+++ b/tests/Credentials/GCECredentialsTest.php
@@ -42,6 +42,12 @@ class GCECredentialsTest extends BaseTest
 {
     use ProphecyTrait;
 
+    protected function tearDown(): void
+    {
+        skipGceCheck(false);
+        parent::tearDown();
+    }
+
     public function testOnGceMetadataFlavorHeader()
     {
         $hasHeader = false;
@@ -74,8 +80,19 @@ class GCECredentialsTest extends BaseTest
         $this->assertTrue($handerInvoked);
     }
 
+    public function testOnGceIsFalseWhenNoGceCheckEnvVarSet()
+    {
+        skipGceCheck();
+        $httpHandler = getHandler([
+            new Response(200, [GCECredentials::FLAVOR_HEADER => 'Google']),
+        ]);
+        $this->assertFalse(GCECredentials::onGce($httpHandler));
+    }
+
     public function testOnGCEIsFalseOnClientErrorStatus()
     {
+        skipGceCheck();
+
         // simulate retry attempts by returning multiple 400s
         $httpHandler = getHandler([
             new Response(400),
@@ -87,6 +104,8 @@ class GCECredentialsTest extends BaseTest
 
     public function testOnGCEIsFalseOnServerErrorStatus()
     {
+        skipGceCheck();
+
         // simulate retry attempts by returning multiple 500s
         $httpHandler = getHandler([
             new Response(500),
@@ -98,6 +117,8 @@ class GCECredentialsTest extends BaseTest
 
     public function testOnGCEIsFalseOnNetworkError()
     {
+        skipGceCheck();
+
         // simulate retry attempts by returning multiple network errors
         $httpHandler = getHandler([
             new ConnectException('Connection refused', new Request('GET', 'test')),
@@ -235,6 +256,8 @@ class GCECredentialsTest extends BaseTest
 
     public function testFetchAuthTokenShouldBeEmptyIfNotOnGCE()
     {
+        skipGceCheck();
+
         // simulate retry attempts by returning multiple 500s
         $httpHandler = getHandler([
             new Response(500),
@@ -392,6 +415,8 @@ class GCECredentialsTest extends BaseTest
 
     public function testGetClientNameShouldBeEmptyIfNotOnGCE()
     {
+        skipGceCheck();
+
         // simulate retry attempts by returning multiple 500s
         $httpHandler = getHandler([
             new Response(500),

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,14 +41,12 @@ function setHomeEnv(string|null $value): void
     putenv($assigment);
 }
 
-function skipGceCheck(bool $skip = true): void
+function skipResidencyCheck(bool $skip = true): void
 {
-    $assignment = sprintf(
-        '%s%s',
-        \Google\Auth\Credentials\GCECredentials::NO_GCE_CHECK_ENV_VAR,
-        $skip ? '=true' : ''
+    $prop = new \ReflectionProperty(
+        \Google\Auth\Credentials\GCECredentials::class,
+        'checkResidency'
     );
-
-    putenv($assignment);
+    $prop->setAccessible(true);
+    $prop->setValue(null, !$skip);
 }
-

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -47,6 +47,5 @@ function skipResidencyCheck(bool $skip = true): void
         \Google\Auth\Credentials\GCECredentials::class,
         'checkResidency'
     );
-    $prop->setAccessible(true);
     $prop->setValue(null, !$skip);
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,3 +40,15 @@ function setHomeEnv(string|null $value): void
 
     putenv($assigment);
 }
+
+function skipGceCheck(bool $skip = true): void
+{
+    $assignment = sprintf(
+        '%s%s',
+        \Google\Auth\Credentials\GCECredentials::NO_GCE_CHECK_ENV_VAR,
+        $skip ? '=true' : ''
+    );
+
+    putenv($assignment);
+}
+


### PR DESCRIPTION
### Problem
When running unit tests on Google-managed machines (such as Cloudtop or GCP VMs), tests in `GCECredentialsTest` and `ApplicationDefaultCredentialsTest` that simulate non-GCE environments fail.

Although tests mock HTTP failure responses from the metadata server, `GCECredentials::onGce()` falls back to checking the host's SMBIOS product name (`/sys/class/dmi/id/product_name`). Because Cloudtop instances run on Google infrastructure, this file contains `Google Compute Engine`, causing `onGce()` to evaluate to `true` and breaking assertions that expect non-GCE behavior.

### Solution
1. Added support for the standard `NO_GCE_CHECK` environment variable in `GCECredentials::onGce()` (matching parity with Python `google-auth` and Java `google-auth-library-java`). When set, `onGce()` immediately returns `false` without pinging or checking SMBIOS.
2. Added a `skipGceCheck()` helper in `tests/bootstrap.php` (similar to `setHomeEnv()`) and updated tests that verify non-GCE behavior.
3. Added a unit test verifying `NO_GCE_CHECK` behavior.

The tests are now working on my cloudtop.

BEGIN_COMMIT_OVERRIDE
chore(tests): add private static variable to skip GCE residency checks (#682)

END_COMMIT_OVERRIDE